### PR TITLE
Pagination

### DIFF
--- a/src/server/api/routers/plan.ts
+++ b/src/server/api/routers/plan.ts
@@ -2,16 +2,22 @@ import { z } from "zod";
 
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { env } from "../../../env.mjs";
+import { addDays } from "date-fns";
 
 export const planRouter = createTRPCRouter({
-  plannedDinners: publicProcedure.query(async ({ ctx }) => {
-    const plans = await ctx.db.plan.findMany({
-      include: { dinner: true },
-      orderBy: { date: "asc" },
-    });
+  plannedDinners: publicProcedure
+    .input(z.object({ startOfWeek: z.date() }))
+    .query(async ({ ctx, input }) => {
+      const plans = await ctx.db.plan.findMany({
+        where: {
+          date: { gte: input.startOfWeek, lt: addDays(input.startOfWeek, 7) },
+        },
+        include: { dinner: true },
+        orderBy: { date: "asc" },
+      });
 
-    return { plans };
-  }),
+      return { plans };
+    }),
   planDinnerForDate: publicProcedure
     .input(
       z.object({

--- a/src/views/Dinners/DialogWeek.tsx
+++ b/src/views/Dinners/DialogWeek.tsx
@@ -143,28 +143,31 @@ const NoDinnerPlanned = ({ date, selectedDinner }: NoDinnerPlannedProps) => {
 
       const prevPlannedDinners = utils.plan.plannedDinners.getData();
 
-      utils.plan.plannedDinners.setData(undefined, (old) => {
-        const oldPlans = old?.plans ?? [];
+      utils.plan.plannedDinners.setData(
+        { startOfWeek: startOfWeek(date ?? new Date(), { weekStartsOn: 1 }) },
+        (old) => {
+          const oldPlans = old?.plans ?? [];
 
-        return {
-          plans: [
-            ...oldPlans,
-            {
-              date: input.date,
-              dinner: selectedDinner,
-              dinnerId: selectedDinner.id,
-              id: Math.ceil(Math.random() * -10000),
-            },
-          ],
-        };
-      });
+          return {
+            plans: [
+              ...oldPlans,
+              {
+                date: input.date,
+                dinner: selectedDinner,
+                dinnerId: selectedDinner.id,
+                id: Math.ceil(Math.random() * -10000),
+              },
+            ],
+          };
+        },
+      );
 
       return { prevPlannedDinners };
     },
     onError: (_, __, context) => {
       if (context?.prevPlannedDinners) {
         utils.plan.plannedDinners.setData(
-          undefined,
+          { startOfWeek: startOfWeek(date ?? new Date(), { weekStartsOn: 1 }) },
           context.prevPlannedDinners,
         );
       }
@@ -217,22 +220,25 @@ const DinnerPlanned = ({
 
       const prevPlannedDinners = utils.plan.plannedDinners.getData();
 
-      utils.plan.plannedDinners.setData(undefined, (old) => {
-        const oldPlans = old?.plans ?? [];
+      utils.plan.plannedDinners.setData(
+        { startOfWeek: startOfWeek(date ?? new Date(), { weekStartsOn: 1 }) },
+        (old) => {
+          const oldPlans = old?.plans ?? [];
 
-        return {
-          plans: oldPlans.filter(
-            (oldPlan) => !isSameDay(oldPlan.date, input.date),
-          ),
-        };
-      });
+          return {
+            plans: oldPlans.filter(
+              (oldPlan) => !isSameDay(oldPlan.date, input.date),
+            ),
+          };
+        },
+      );
 
       return { prevPlannedDinners };
     },
     onError: (_, __, context) => {
       if (context?.prevPlannedDinners) {
         utils.plan.plannedDinners.setData(
-          undefined,
+          { startOfWeek: startOfWeek(date ?? new Date(), { weekStartsOn: 1 }) },
           context.prevPlannedDinners,
         );
       }
@@ -254,29 +260,32 @@ const DinnerPlanned = ({
 
       const prevPlannedDinners = utils.plan.plannedDinners.getData();
 
-      utils.plan.plannedDinners.setData(undefined, (old) => {
-        const oldPlan = old?.plans ?? [];
+      utils.plan.plannedDinners.setData(
+        { startOfWeek: startOfWeek(date ?? new Date(), { weekStartsOn: 1 }) },
+        (old) => {
+          const oldPlan = old?.plans ?? [];
 
-        return {
-          plans: oldPlan.map((plan) => {
-            if (isSameDay(plan.date, input.date)) {
-              return {
-                ...plan,
-                dinnerId: input.dinnerId,
-                dinner: selectedDinner,
-              };
-            }
+          return {
+            plans: oldPlan.map((plan) => {
+              if (isSameDay(plan.date, input.date)) {
+                return {
+                  ...plan,
+                  dinnerId: input.dinnerId,
+                  dinner: selectedDinner,
+                };
+              }
 
-            return plan;
-          }),
-        };
-      });
+              return plan;
+            }),
+          };
+        },
+      );
       return { prevPlannedDinners };
     },
     onError: (_, __, context) => {
       if (context?.prevPlannedDinners) {
         utils.plan.plannedDinners.setData(
-          undefined,
+          { startOfWeek: startOfWeek(date ?? new Date(), { weekStartsOn: 1 }) },
           context.prevPlannedDinners,
         );
       }

--- a/src/views/Dinners/DialogWeek.tsx
+++ b/src/views/Dinners/DialogWeek.tsx
@@ -2,23 +2,37 @@ import { type Dinner } from "@prisma/client";
 import { cn } from "../../lib/utils";
 import { api } from "../../utils/api";
 import { usePostHog } from "posthog-js/react";
-import { startOfDay, addDays, isSameDay, format } from "date-fns";
+import { startOfDay, addDays, isSameDay, format, startOfWeek } from "date-fns";
 import { UtensilsCrossed } from "lucide-react";
+import { useState } from "react";
+import { WeekSelect } from "../WeekSelect";
 
 type Props = { selectedDinner: Dinner; closeDialog: () => void };
 
 export const DialogWeek = ({ selectedDinner, closeDialog }: Props) => {
-  const plannedDinnersQuery = api.plan.plannedDinners.useQuery();
+  const [weekOfSet, setWeekOfSet] = useState(0);
+
+  const startOfCurrentWeek = startOfWeek(new Date(), {
+    weekStartsOn: 1,
+  });
+  const startOfDisplayedWeek = addDays(startOfCurrentWeek, weekOfSet * 7);
 
   const week: Date[] = [
-    startOfDay(new Date()),
-    startOfDay(addDays(new Date(), 1)),
-    startOfDay(addDays(new Date(), 2)),
-    startOfDay(addDays(new Date(), 3)),
-    startOfDay(addDays(new Date(), 4)),
-    startOfDay(addDays(new Date(), 5)),
-    startOfDay(addDays(new Date(), 6)),
+    startOfDay(startOfDisplayedWeek),
+    startOfDay(addDays(startOfDisplayedWeek, 1)),
+    startOfDay(addDays(startOfDisplayedWeek, 2)),
+    startOfDay(addDays(startOfDisplayedWeek, 3)),
+    startOfDay(addDays(startOfDisplayedWeek, 4)),
+    startOfDay(addDays(startOfDisplayedWeek, 5)),
+    startOfDay(addDays(startOfDisplayedWeek, 6)),
   ];
+
+  const plannedDinnersQuery = api.plan.plannedDinners.useQuery(
+    {
+      startOfWeek: startOfDisplayedWeek,
+    },
+    { keepPreviousData: true },
+  );
 
   if (plannedDinnersQuery.isLoading) {
     return (
@@ -30,6 +44,10 @@ export const DialogWeek = ({ selectedDinner, closeDialog }: Props) => {
 
   return (
     <div className="flex w-full flex-col gap-2 overflow-y-auto">
+      <WeekSelect
+        setWeekOfSet={setWeekOfSet}
+        startOfDisplayedWeek={startOfDisplayedWeek}
+      />
       {week.map((day) => (
         <Day
           key={day.toString()}

--- a/src/views/Plan/DialogDinners.tsx
+++ b/src/views/Plan/DialogDinners.tsx
@@ -1,4 +1,4 @@
-import { type Dinner } from "@prisma/client";
+import { type Plan, type Dinner } from "@prisma/client";
 import { cn } from "../../lib/utils";
 import { api } from "../../utils/api";
 import { usePostHog } from "posthog-js/react";
@@ -48,21 +48,23 @@ const DialogDinner = ({
       utils.plan.plannedDinners.setData(
         { startOfWeek: startOfWeek(date ?? new Date(), { weekStartsOn: 1 }) },
         (old) => {
-          // TODO Handle when there is a new dinner
+          const oldPlans = old?.plans ?? [];
+          const alreadyPlanned = oldPlans.find((plan) =>
+            isSameDay(plan.date, input.date),
+          );
+          const newPlan: Plan & { dinner: Dinner } = {
+            ...alreadyPlanned,
+            dinnerId: input.dinnerId,
+            dinner,
+            id: alreadyPlanned?.id ?? Math.ceil(Math.random() * -10000),
+            date: input.date,
+          };
 
           return {
-            plans:
-              old?.plans.map((plan) => {
-                if (isSameDay(plan.date, input.date)) {
-                  return {
-                    ...plan,
-                    dinnerId: input.dinnerId,
-                    dinner: dinner,
-                  };
-                }
-
-                return plan;
-              }) ?? [],
+            plans: [
+              ...oldPlans.filter((plan) => plan.id !== newPlan.id),
+              newPlan,
+            ],
           };
         },
       );

--- a/src/views/Plan/PlanView.tsx
+++ b/src/views/Plan/PlanView.tsx
@@ -17,6 +17,7 @@ export const WeekView = () => {
   const [selectedDay, setSelectedDay] = useState<Date>();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [weekOfSet, setWeekOfSet] = useState(0);
+  const trpc = api.useUtils();
 
   const startOfCurrentWeek = startOfWeek(new Date(), {
     weekStartsOn: 1,
@@ -38,6 +39,20 @@ export const WeekView = () => {
       startOfWeek: startOfDisplayedWeek,
     },
     { keepPreviousData: true },
+  );
+
+  void trpc.plan.plannedDinners.prefetch(
+    {
+      startOfWeek: addDays(startOfDisplayedWeek, 7),
+    },
+    { staleTime: 60 * 1000 },
+  );
+
+  void trpc.plan.plannedDinners.prefetch(
+    {
+      startOfWeek: addDays(startOfDisplayedWeek, -7),
+    },
+    { staleTime: 60 * 1000 },
   );
 
   if (plannedDinnersQuery.isLoading) {

--- a/src/views/Plan/PlanView.tsx
+++ b/src/views/Plan/PlanView.tsx
@@ -33,9 +33,12 @@ export const WeekView = () => {
     startOfDay(addDays(startOfDisplayedWeek, 6)),
   ];
 
-  const plannedDinnersQuery = api.plan.plannedDinners.useQuery({
-    startOfWeek: startOfDisplayedWeek,
-  });
+  const plannedDinnersQuery = api.plan.plannedDinners.useQuery(
+    {
+      startOfWeek: startOfDisplayedWeek,
+    },
+    { keepPreviousData: true },
+  );
 
   if (plannedDinnersQuery.isLoading) {
     return (

--- a/src/views/Plan/PlanView.tsx
+++ b/src/views/Plan/PlanView.tsx
@@ -78,6 +78,10 @@ export const WeekView = () => {
               }
             />
           ))}
+          <WeekSelect
+            setWeekOfSet={setWeekOfSet}
+            startOfDisplayedWeek={startOfDisplayedWeek}
+          />
         </div>
         <PlanDayDialog
           date={selectedDay}

--- a/src/views/Plan/PlanView.tsx
+++ b/src/views/Plan/PlanView.tsx
@@ -18,8 +18,6 @@ export const WeekView = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [weekOfSet, setWeekOfSet] = useState(0);
 
-  const plannedDinnersQuery = api.plan.plannedDinners.useQuery();
-
   const startOfCurrentWeek = startOfWeek(new Date(), {
     weekStartsOn: 1,
   });
@@ -34,6 +32,10 @@ export const WeekView = () => {
     startOfDay(addDays(startOfDisplayedWeek, 5)),
     startOfDay(addDays(startOfDisplayedWeek, 6)),
   ];
+
+  const plannedDinnersQuery = api.plan.plannedDinners.useQuery({
+    startOfWeek: startOfDisplayedWeek,
+  });
 
   if (plannedDinnersQuery.isLoading) {
     return (

--- a/src/views/Plan/PlanView.tsx
+++ b/src/views/Plan/PlanView.tsx
@@ -1,17 +1,11 @@
-import {
-  Calendar,
-  ChevronLeft,
-  ChevronRight,
-  UtensilsCrossed,
-} from "lucide-react";
+import { UtensilsCrossed } from "lucide-react";
 import { Dialog } from "../../components/ui/dialog";
 import { api } from "../../utils/api";
 import { BottomNav } from "../BottomNav";
 import { Day } from "./Day";
 import { PlanDayDialog } from "./PlanDayDialog";
-import { type Dispatch, type SetStateAction, useState } from "react";
-import { addDays, format, isSameDay, startOfDay, startOfWeek } from "date-fns";
-import { Button } from "../../components/ui/button";
+import { useState } from "react";
+import { addDays, isSameDay, startOfDay, startOfWeek } from "date-fns";
 import { WeekSelect } from "../WeekSelect";
 
 export const WeekView = () => {

--- a/src/views/Plan/PlanView.tsx
+++ b/src/views/Plan/PlanView.tsx
@@ -12,6 +12,7 @@ import { PlanDayDialog } from "./PlanDayDialog";
 import { type Dispatch, type SetStateAction, useState } from "react";
 import { addDays, format, isSameDay, startOfDay, startOfWeek } from "date-fns";
 import { Button } from "../../components/ui/button";
+import { WeekSelect } from "../WeekSelect";
 
 export const WeekView = () => {
   const [selectedDay, setSelectedDay] = useState<Date>();
@@ -99,51 +100,5 @@ export const WeekView = () => {
 
       <BottomNav />
     </div>
-  );
-};
-
-type WeekSelectProps = {
-  setWeekOfSet: Dispatch<SetStateAction<number>>;
-  startOfDisplayedWeek: Date;
-};
-
-const WeekSelect = ({
-  setWeekOfSet,
-  startOfDisplayedWeek,
-}: WeekSelectProps) => {
-  return (
-    <>
-      <div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            className="h-8 w-8 p-0"
-            onClick={() => setWeekOfSet((prev) => prev - 1)}
-          >
-            <span className="sr-only">Go back 1 week</span>
-            <ChevronLeft className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="outline"
-            className="h-8 w-8 p-0"
-            onClick={() => setWeekOfSet(0)}
-          >
-            <span className="sr-only">Go to today</span>
-            <Calendar className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="outline"
-            className="h-8 w-8 p-0"
-            onClick={() => setWeekOfSet((prev) => prev + 1)}
-          >
-            <span className="sr-only">Go forward 1 week</span>
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-          <div className="px-4 text-sm font-medium">
-            Week {format(startOfDisplayedWeek, "w, MMMM, yyyy")}
-          </div>
-        </div>
-      </div>
-    </>
   );
 };

--- a/src/views/WeekSelect.tsx
+++ b/src/views/WeekSelect.tsx
@@ -1,0 +1,50 @@
+import { format } from "date-fns";
+import { ChevronLeft, Calendar, ChevronRight } from "lucide-react";
+import { type Dispatch, type SetStateAction } from "react";
+import { Button } from "../components/ui/button";
+
+type WeekSelectProps = {
+  setWeekOfSet: Dispatch<SetStateAction<number>>;
+  startOfDisplayedWeek: Date;
+};
+
+export const WeekSelect = ({
+  setWeekOfSet,
+  startOfDisplayedWeek,
+}: WeekSelectProps) => {
+  return (
+    <>
+      <div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            className="h-8 w-8 p-0"
+            onClick={() => setWeekOfSet((prev) => prev - 1)}
+          >
+            <span className="sr-only">Go back 1 week</span>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className="h-8 w-8 p-0"
+            onClick={() => setWeekOfSet(0)}
+          >
+            <span className="sr-only">Go to today</span>
+            <Calendar className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className="h-8 w-8 p-0"
+            onClick={() => setWeekOfSet((prev) => prev + 1)}
+          >
+            <span className="sr-only">Go forward 1 week</span>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <div className="px-4 text-sm font-medium">
+            Week {format(startOfDisplayedWeek, "w, MMMM, yyyy")}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
This PR sets up pagination for the plans query. It really isn't an issue and won't be for a long time, but before this we just fetched all plans in the db, even though we only displayed the current week. Now we fetch the current week and prefetch last and next week. 

We also put the week select at the bottom as well as the top of the week view. It should be easier to reach on mobiles now. I probably will just attach it to the nav bar, but this was quick and easy. 