### PR TITLE
[codex] Add web recipe detail and editor

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -16,7 +16,7 @@ import { Quicksand_400Regular } from "@expo-google-fonts/quicksand";
 import { YoungSerif_400Regular } from "@expo-google-fonts/young-serif";
 import { ClerkProvider } from "./src/providers/ClerkProvider";
 import { TRPCProvider } from "./src/providers/TRPCProvider";
-import { AppTabs } from "./src/navigation/AppTabs";
+import { RootNavigator } from "./src/navigation/RootNavigator";
 import { OnboardingScreen } from "./src/screens/OnboardingScreen";
 import { linking } from "./src/navigation/linking";
 import { AuthScreen } from "./src/screens/AuthScreen";
@@ -112,5 +112,5 @@ function HouseholdGate() {
     return <OnboardingScreen />;
   }
 
-  return <AppTabs />;
+  return <RootNavigator />;
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -18,6 +18,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@planeatrepeat/shared": "workspace:*",
     "@react-navigation/bottom-tabs": "^7.3.9",
+    "@react-navigation/elements": "^2.9.5",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.9",
     "@tanstack/react-query": "^5.90.12",

--- a/apps/mobile/src/components/dinners/DinnerForm.tsx
+++ b/apps/mobile/src/components/dinners/DinnerForm.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { View, Text, Alert } from "react-native";
+import { View, Text } from "react-native";
 import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { dinnerFormSchema, type DinnerWithTags } from "@planeatrepeat/shared";
+import { dinnerFormSchema } from "@planeatrepeat/shared";
 import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
 import { Textarea } from "../ui/Textarea";
@@ -18,28 +18,20 @@ type DinnerFormValues = {
 };
 
 type Props = {
-  existingDinner?: DinnerWithTags | null;
   onSubmit: (values: DinnerFormValues) => void;
-  onDelete?: (values: DinnerFormValues) => void;
   onCancel: () => void;
   isPending: boolean;
 };
 
-export function DinnerForm({
-  existingDinner,
-  onSubmit,
-  onDelete,
-  onCancel,
-  isPending,
-}: Props) {
+export function DinnerForm({ onSubmit, onCancel, isPending }: Props) {
   const form = useForm<DinnerFormValues>({
     resolver: zodResolver(dinnerFormSchema),
     defaultValues: {
-      name: existingDinner?.name ?? "",
-      tags: existingDinner?.tags.map((tag) => tag.value) ?? [],
+      name: "",
+      tags: [],
       newTag: "",
-      link: existingDinner?.link ?? "",
-      notes: existingDinner?.notes ?? "",
+      link: "",
+      notes: "",
     },
   });
 
@@ -64,18 +56,6 @@ export function DinnerForm({
     );
   };
 
-  const handleDelete = () => {
-    if (!onDelete) return;
-    Alert.alert("Delete dinner", "Are you sure you want to delete this dinner?", [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: () => form.handleSubmit(onDelete)(),
-      },
-    ]);
-  };
-
   return (
     <View className="gap-5">
       <Controller
@@ -83,14 +63,14 @@ export function DinnerForm({
         name="name"
         render={({ field }) => (
           <View className="gap-2">
-            <Text className="text-sm font-medium text-foreground">Name</Text>
+            <Text className="text-foreground text-sm font-medium">Name</Text>
             <Input value={field.value} onChangeText={field.onChange} />
           </View>
         )}
       />
 
       <View className="gap-2">
-        <Text className="text-sm font-medium text-foreground">Tags</Text>
+        <Text className="text-foreground text-sm font-medium">Tags</Text>
         <View className="flex-row flex-wrap gap-2">
           {tags.map((tag) => (
             <Badge key={tag} variant="secondary" onPress={() => removeTag(tag)}>
@@ -116,11 +96,7 @@ export function DinnerForm({
         {!!existingTags?.length && (
           <View className="flex-row flex-wrap gap-2">
             {existingTags.map((tag) => (
-              <Badge
-                key={tag}
-                variant="outline"
-                onPress={() => addTag(tag)}
-              >
+              <Badge key={tag} variant="outline" onPress={() => addTag(tag)}>
                 {tag}
               </Badge>
             ))}
@@ -133,7 +109,7 @@ export function DinnerForm({
         name="link"
         render={({ field }) => (
           <View className="gap-2">
-            <Text className="text-sm font-medium text-foreground">Link</Text>
+            <Text className="text-foreground text-sm font-medium">Link</Text>
             <Input value={field.value} onChangeText={field.onChange} />
           </View>
         )}
@@ -144,7 +120,7 @@ export function DinnerForm({
         name="notes"
         render={({ field }) => (
           <View className="gap-2">
-            <Text className="text-sm font-medium text-foreground">Notes</Text>
+            <Text className="text-foreground text-sm font-medium">Notes</Text>
             <Textarea value={field.value} onChangeText={field.onChange} />
           </View>
         )}
@@ -154,11 +130,6 @@ export function DinnerForm({
         <Button onPress={form.handleSubmit(onSubmit)} disabled={isPending}>
           Save
         </Button>
-        {existingDinner && onDelete && (
-          <Button variant="destructive" onPress={handleDelete} disabled={isPending}>
-            Delete
-          </Button>
-        )}
         <Button variant="outline" onPress={onCancel}>
           Cancel
         </Button>

--- a/apps/mobile/src/components/dinners/RecipeEditor.tsx
+++ b/apps/mobile/src/components/dinners/RecipeEditor.tsx
@@ -38,6 +38,7 @@ import {
 import {
   UNITS,
   type DinnerWithRecipe,
+  amountInputSchema,
   recipeIngredientSchema,
 } from "@planeatrepeat/shared";
 import { api } from "../../utils/api";
@@ -47,25 +48,9 @@ import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
 import { Textarea } from "../ui/Textarea";
 
-// Amounts are edited as text so partial input like "1," or "0.5" survives
-// re-renders; parseAmount converts back to a number on save.
-export const parseAmount = (value: string) => {
-  const normalized = value.trim().replace(",", ".");
-  if (normalized === "") return null;
-  const parsed = Number(normalized);
-  return Number.isNaN(parsed) ? null : parsed;
-};
-
 const editorIngredientSchema = recipeIngredientSchema.extend({
   name: z.string().trim().min(1, "Name required"),
-  amount: z
-    .string()
-    .trim()
-    .refine((value) => {
-      if (value === "") return true;
-      const parsed = Number(value.replace(",", "."));
-      return !Number.isNaN(parsed) && parsed > 0;
-    }, "Amount must be a number more than 0"),
+  amount: amountInputSchema,
   note: z.string(),
 });
 
@@ -211,7 +196,8 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
           }}
         >
           <View className="gap-5">
-            <View>
+            <View className="gap-1.5">
+              <FieldLabel>Name</FieldLabel>
               <Controller
                 control={form.control}
                 name="name"
@@ -222,7 +208,6 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
                     onChangeText={field.onChange}
                     accessibilityLabel="Dinner name"
                     className="h-12 bg-white text-lg font-semibold"
-                    placeholder="Dinner name"
                   />
                 )}
               />
@@ -231,66 +216,74 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
 
             <View>
               <View className="flex-row gap-2">
-                <View className="border-border h-11 w-[116px] flex-row overflow-hidden rounded-md border bg-white">
-                  <Pressable
-                    accessibilityLabel="Decrease servings"
-                    className="border-border w-9 items-center justify-center border-r"
-                    onPress={() =>
-                      form.setValue(
-                        "recipe.servings",
-                        Math.max(1, (servings ?? 2) - 1),
-                        { shouldDirty: true },
-                      )
-                    }
-                  >
-                    <Minus size={16} color={colors.mutedForeground} />
-                  </Pressable>
+                <View className="gap-1.5">
+                  <FieldLabel>Servings</FieldLabel>
+                  <View className="border-border h-11 w-[116px] flex-row overflow-hidden rounded-md border bg-white">
+                    <Pressable
+                      accessibilityLabel="Decrease servings"
+                      className="border-border w-9 items-center justify-center border-r"
+                      onPress={() =>
+                        form.setValue(
+                          "recipe.servings",
+                          Math.max(1, (servings ?? 2) - 1),
+                          { shouldDirty: true },
+                        )
+                      }
+                    >
+                      <Minus size={16} color={colors.mutedForeground} />
+                    </Pressable>
+                    <Controller
+                      control={form.control}
+                      name="recipe.servings"
+                      render={({ field }) => (
+                        <Input
+                          value={
+                            field.value === null ? "" : String(field.value)
+                          }
+                          onBlur={field.onBlur}
+                          onChangeText={(value) =>
+                            field.onChange(value === "" ? null : Number(value))
+                          }
+                          accessibilityLabel="Number of servings"
+                          keyboardType="number-pad"
+                          textAlign="center"
+                          className="min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 py-0 font-bold"
+                          placeholder="–"
+                        />
+                      )}
+                    />
+                    <Pressable
+                      accessibilityLabel="Increase servings"
+                      className="border-border w-9 items-center justify-center border-l"
+                      onPress={() =>
+                        form.setValue("recipe.servings", (servings ?? 0) + 1, {
+                          shouldDirty: true,
+                        })
+                      }
+                    >
+                      <Plus size={16} color={colors.mutedForeground} />
+                    </Pressable>
+                  </View>
+                </View>
+
+                <View className="min-w-0 flex-1 gap-1.5">
+                  <FieldLabel>Recipe link</FieldLabel>
                   <Controller
                     control={form.control}
-                    name="recipe.servings"
+                    name="link"
                     render={({ field }) => (
                       <Input
-                        value={field.value === null ? "" : String(field.value)}
+                        value={field.value}
                         onBlur={field.onBlur}
-                        onChangeText={(value) =>
-                          field.onChange(value === "" ? null : Number(value))
-                        }
-                        accessibilityLabel="Number of servings"
-                        keyboardType="number-pad"
-                        className="min-w-0 flex-1 rounded-none border-0 bg-transparent px-1 text-center font-bold"
-                        placeholder="–"
+                        onChangeText={field.onChange}
+                        accessibilityLabel="Recipe link"
+                        autoCapitalize="none"
+                        keyboardType="url"
+                        className="h-11 bg-white"
                       />
                     )}
                   />
-                  <Pressable
-                    accessibilityLabel="Increase servings"
-                    className="border-border w-9 items-center justify-center border-l"
-                    onPress={() =>
-                      form.setValue("recipe.servings", (servings ?? 0) + 1, {
-                        shouldDirty: true,
-                      })
-                    }
-                  >
-                    <Plus size={16} color={colors.mutedForeground} />
-                  </Pressable>
                 </View>
-
-                <Controller
-                  control={form.control}
-                  name="link"
-                  render={({ field }) => (
-                    <Input
-                      value={field.value}
-                      onBlur={field.onBlur}
-                      onChangeText={field.onChange}
-                      accessibilityLabel="Recipe link"
-                      autoCapitalize="none"
-                      keyboardType="url"
-                      className="h-11 min-w-0 flex-1 bg-white"
-                      placeholder="Recipe link"
-                    />
-                  )}
-                />
               </View>
               <FieldError
                 message={
@@ -300,7 +293,10 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
               />
             </View>
 
-            <EditorTags form={form} />
+            <View className="gap-1.5">
+              <FieldLabel>Tags</FieldLabel>
+              <EditorTags form={form} />
+            </View>
 
             <View className="border-t border-[hsl(40,15%,86%)] pt-5">
               {parts.fields.map((part, partIndex) => (
@@ -333,7 +329,7 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
             </View>
 
             <View className="gap-2 border-t border-[hsl(40,15%,86%)] pt-5">
-              <Text className="text-foreground font-serif text-base">Tips</Text>
+              <SectionLabel>Notes</SectionLabel>
               <Controller
                 control={form.control}
                 name="notes"
@@ -432,45 +428,48 @@ function PartEditor({
           "mt-6 border-t border-[hsl(40,15%,86%)] pt-5",
       )}
     >
-      {multiMode ? (
-        <View className="mb-3 flex-row items-center gap-2">
-          <Controller
-            control={form.control}
-            name={`recipe.parts.${partIndex}.name`}
-            render={({ field }) => (
-              <Input
-                value={field.value}
-                onBlur={field.onBlur}
-                onChangeText={field.onChange}
-                accessibilityLabel={`Part ${partIndex + 1} name`}
-                className="h-11 min-w-0 flex-1 bg-white font-serif text-base"
-                placeholder="Part name (optional)"
-              />
-            )}
-          />
-          <View className="flex-row">
-            <IconButton
-              label="Move part up"
-              disabled={!canMoveUp}
-              onPress={onMoveUp}
-            >
-              <ArrowUp size={17} color={colors.mutedForeground} />
-            </IconButton>
-            <IconButton
-              label="Move part down"
-              disabled={!canMoveDown}
-              onPress={onMoveDown}
-            >
-              <ArrowDown size={17} color={colors.mutedForeground} />
-            </IconButton>
-            <IconButton label="Remove part" onPress={onRemove}>
-              <X size={18} color={colors.destructive} />
-            </IconButton>
+      {multiMode && (
+        <View className="mb-4 gap-1.5">
+          <FieldLabel>Part name</FieldLabel>
+          <View className="flex-row items-center gap-2">
+            <Controller
+              control={form.control}
+              name={`recipe.parts.${partIndex}.name`}
+              render={({ field }) => (
+                <Input
+                  value={field.value}
+                  onBlur={field.onBlur}
+                  onChangeText={field.onChange}
+                  accessibilityLabel={`Part ${partIndex + 1} name`}
+                  className="h-11 min-w-0 flex-1 bg-white font-serif text-base"
+                  placeholder="Optional"
+                />
+              )}
+            />
+            <View className="flex-row">
+              <IconButton
+                label="Move part up"
+                disabled={!canMoveUp}
+                onPress={onMoveUp}
+              >
+                <ArrowUp size={17} color={colors.mutedForeground} />
+              </IconButton>
+              <IconButton
+                label="Move part down"
+                disabled={!canMoveDown}
+                onPress={onMoveDown}
+              >
+                <ArrowDown size={17} color={colors.mutedForeground} />
+              </IconButton>
+              <IconButton label="Remove part" onPress={onRemove}>
+                <X size={18} color={colors.destructive} />
+              </IconButton>
+            </View>
           </View>
         </View>
-      ) : (
-        <SectionLabel>Ingredients</SectionLabel>
       )}
+
+      <SectionLabel>Ingredients</SectionLabel>
 
       <View className="mt-2">
         {ingredients.fields.map((ingredient, ingredientIndex) => {
@@ -505,7 +504,7 @@ function PartEditor({
                   "rounded-[10px] border border-[hsl(18,60%,80%)] bg-[hsl(40,33%,95%)]",
               )}
             >
-              <View className="flex-row items-center gap-1.5">
+              <View className="flex-row items-start gap-1.5">
                 <Controller
                   control={form.control}
                   name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.amount`}
@@ -516,8 +515,8 @@ function PartEditor({
                       onChangeText={field.onChange}
                       accessibilityLabel={`Ingredient ${ingredientIndex + 1} amount`}
                       keyboardType="decimal-pad"
-                      className="h-10 w-[52px] bg-white px-1 text-center font-bold"
-                      placeholder="0"
+                      textAlign="center"
+                      className="h-11 w-[64px] bg-white px-1 py-0 font-bold"
                     />
                   )}
                 />
@@ -527,7 +526,7 @@ function PartEditor({
                   render={({ field }) => (
                     <Pressable
                       accessibilityLabel={`Ingredient ${ingredientIndex + 1} unit`}
-                      className="border-input h-10 w-[58px] items-center justify-center rounded-md border bg-white"
+                      className="border-input h-11 w-[56px] items-center justify-center rounded-md border bg-white"
                       onPress={() => open(ingredient.id)}
                     >
                       <Text className="text-foreground text-sm">
@@ -536,34 +535,37 @@ function PartEditor({
                     </Pressable>
                   )}
                 />
-                <Controller
-                  control={form.control}
-                  name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`}
-                  render={({ field }) => (
-                    <Input
-                      value={field.value}
-                      onBlur={() => {
-                        field.onBlur();
-                        setTimeout(() => setFocusedIngredient(null), 150);
-                      }}
-                      onFocus={() => {
-                        open(ingredient.id);
-                        setFocusedIngredient(ingredient.id);
-                      }}
-                      onChangeText={field.onChange}
-                      accessibilityLabel={`Ingredient ${ingredientIndex + 1} name`}
-                      className="h-10 min-w-0 flex-1 bg-white px-2"
-                      placeholder="Ingredient"
-                    />
-                  )}
-                />
+                <View className="min-w-0 flex-1">
+                  <Controller
+                    control={form.control}
+                    name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`}
+                    render={({ field }) => (
+                      <Input
+                        value={field.value}
+                        onBlur={() => {
+                          field.onBlur();
+                          setTimeout(() => setFocusedIngredient(null), 150);
+                        }}
+                        onFocus={() => {
+                          open(ingredient.id);
+                          setFocusedIngredient(ingredient.id);
+                        }}
+                        onChangeText={field.onChange}
+                        accessibilityLabel={`Ingredient ${ingredientIndex + 1} name`}
+                        className="h-11 bg-white px-2.5"
+                        placeholder="Ingredient"
+                      />
+                    )}
+                  />
+                  <FieldError message={ingredientError?.name?.message} />
+                </View>
                 <Pressable
                   accessibilityLabel={
                     isExpanded
                       ? "Hide ingredient controls"
                       : "Show ingredient controls"
                   }
-                  className="h-10 w-[30px] items-center justify-center"
+                  className="h-11 w-[30px] items-center justify-center"
                   onPress={() => toggle(ingredient.id)}
                 >
                   {isExpanded ? (
@@ -679,7 +681,6 @@ function PartEditor({
               )}
               <FieldError
                 message={
-                  ingredientError?.name?.message ??
                   ingredientError?.amount?.message ??
                   ingredientError?.unit?.message
                 }
@@ -883,6 +884,14 @@ function DeleteDinnerButton({
         Delete dinner
       </Text>
     </Button>
+  );
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Text className="text-muted-foreground text-xs font-semibold">
+      {children}
+    </Text>
   );
 }
 

--- a/apps/mobile/src/components/dinners/RecipeEditor.tsx
+++ b/apps/mobile/src/components/dinners/RecipeEditor.tsx
@@ -25,6 +25,7 @@ import {
   X,
 } from "lucide-react-native";
 import { format } from "date-fns";
+import { useHeaderHeight } from "@react-navigation/elements";
 import { useNavigation, usePreventRemove } from "@react-navigation/native";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -46,9 +47,25 @@ import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
 import { Textarea } from "../ui/Textarea";
 
+// Amounts are edited as text so partial input like "1," or "0.5" survives
+// re-renders; parseAmount converts back to a number on save.
+export const parseAmount = (value: string) => {
+  const normalized = value.trim().replace(",", ".");
+  if (normalized === "") return null;
+  const parsed = Number(normalized);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
 const editorIngredientSchema = recipeIngredientSchema.extend({
   name: z.string().trim().min(1, "Name required"),
-  amount: z.number().positive("Amount must be more than 0").nullable(),
+  amount: z
+    .string()
+    .trim()
+    .refine((value) => {
+      if (value === "") return true;
+      const parsed = Number(value.replace(",", "."));
+      return !Number.isNaN(parsed) && parsed > 0;
+    }, "Amount must be a number more than 0"),
   note: z.string(),
 });
 
@@ -114,7 +131,8 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
             name: part.name ?? "",
             ingredients: part.ingredients.map((ingredient) => ({
               name: ingredient.name,
-              amount: ingredient.amount,
+              amount:
+                ingredient.amount === null ? "" : String(ingredient.amount),
               unit: UNITS.find((unit) => unit === ingredient.unit) ?? null,
               note: ingredient.note ?? "",
             })),
@@ -130,6 +148,7 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
     const watchedParts = form.watch("recipe.parts");
     const servings = form.watch("recipe.servings");
     const navigation = useNavigation();
+    const headerHeight = useHeaderHeight();
     const multiMode =
       watchedParts.length > 1 ||
       watchedParts.some((part) => part.name.trim().length > 0);
@@ -179,7 +198,7 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
       <KeyboardAvoidingView
         className="bg-background flex-1"
         behavior={Platform.OS === "ios" ? "padding" : undefined}
-        keyboardVerticalOffset={Platform.OS === "ios" ? 92 : 0}
+        keyboardVerticalOffset={Platform.OS === "ios" ? headerHeight : 0}
       >
         <ScrollView
           keyboardShouldPersistTaps="handled"
@@ -190,90 +209,94 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
           }}
         >
           <View className="gap-5">
-            <Controller
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <Input
-                  value={field.value}
-                  onBlur={field.onBlur}
-                  onChangeText={field.onChange}
-                  accessibilityLabel="Dinner name"
-                  className="h-12 bg-white text-lg font-semibold"
-                  placeholder="Dinner name"
-                />
-              )}
-            />
-            <FieldError message={form.formState.errors.name?.message} />
-
-            <View className="flex-row gap-2">
-              <View className="border-border h-11 w-[116px] flex-row overflow-hidden rounded-md border bg-white">
-                <Pressable
-                  accessibilityLabel="Decrease servings"
-                  className="border-border w-9 items-center justify-center border-r"
-                  onPress={() =>
-                    form.setValue(
-                      "recipe.servings",
-                      Math.max(1, (servings ?? 2) - 1),
-                      { shouldDirty: true },
-                    )
-                  }
-                >
-                  <Minus size={16} color={colors.mutedForeground} />
-                </Pressable>
-                <Controller
-                  control={form.control}
-                  name="recipe.servings"
-                  render={({ field }) => (
-                    <Input
-                      value={field.value === null ? "" : String(field.value)}
-                      onBlur={field.onBlur}
-                      onChangeText={(value) =>
-                        field.onChange(value === "" ? null : Number(value))
-                      }
-                      accessibilityLabel="Number of servings"
-                      keyboardType="number-pad"
-                      className="min-w-0 flex-1 rounded-none border-0 bg-transparent px-1 text-center font-bold"
-                      placeholder="–"
-                    />
-                  )}
-                />
-                <Pressable
-                  accessibilityLabel="Increase servings"
-                  className="border-border w-9 items-center justify-center border-l"
-                  onPress={() =>
-                    form.setValue("recipe.servings", (servings ?? 0) + 1, {
-                      shouldDirty: true,
-                    })
-                  }
-                >
-                  <Plus size={16} color={colors.mutedForeground} />
-                </Pressable>
-              </View>
-
+            <View>
               <Controller
                 control={form.control}
-                name="link"
+                name="name"
                 render={({ field }) => (
                   <Input
                     value={field.value}
                     onBlur={field.onBlur}
                     onChangeText={field.onChange}
-                    accessibilityLabel="Recipe link"
-                    autoCapitalize="none"
-                    keyboardType="url"
-                    className="h-11 min-w-0 flex-1 bg-white"
-                    placeholder="Recipe link"
+                    accessibilityLabel="Dinner name"
+                    className="h-12 bg-white text-lg font-semibold"
+                    placeholder="Dinner name"
                   />
                 )}
               />
+              <FieldError message={form.formState.errors.name?.message} />
             </View>
-            <FieldError
-              message={
-                form.formState.errors.link?.message ??
-                form.formState.errors.recipe?.servings?.message
-              }
-            />
+
+            <View>
+              <View className="flex-row gap-2">
+                <View className="border-border h-11 w-[116px] flex-row overflow-hidden rounded-md border bg-white">
+                  <Pressable
+                    accessibilityLabel="Decrease servings"
+                    className="border-border w-9 items-center justify-center border-r"
+                    onPress={() =>
+                      form.setValue(
+                        "recipe.servings",
+                        Math.max(1, (servings ?? 2) - 1),
+                        { shouldDirty: true },
+                      )
+                    }
+                  >
+                    <Minus size={16} color={colors.mutedForeground} />
+                  </Pressable>
+                  <Controller
+                    control={form.control}
+                    name="recipe.servings"
+                    render={({ field }) => (
+                      <Input
+                        value={field.value === null ? "" : String(field.value)}
+                        onBlur={field.onBlur}
+                        onChangeText={(value) =>
+                          field.onChange(value === "" ? null : Number(value))
+                        }
+                        accessibilityLabel="Number of servings"
+                        keyboardType="number-pad"
+                        className="min-w-0 flex-1 rounded-none border-0 bg-transparent px-1 text-center font-bold"
+                        placeholder="–"
+                      />
+                    )}
+                  />
+                  <Pressable
+                    accessibilityLabel="Increase servings"
+                    className="border-border w-9 items-center justify-center border-l"
+                    onPress={() =>
+                      form.setValue("recipe.servings", (servings ?? 0) + 1, {
+                        shouldDirty: true,
+                      })
+                    }
+                  >
+                    <Plus size={16} color={colors.mutedForeground} />
+                  </Pressable>
+                </View>
+
+                <Controller
+                  control={form.control}
+                  name="link"
+                  render={({ field }) => (
+                    <Input
+                      value={field.value}
+                      onBlur={field.onBlur}
+                      onChangeText={field.onChange}
+                      accessibilityLabel="Recipe link"
+                      autoCapitalize="none"
+                      keyboardType="url"
+                      className="h-11 min-w-0 flex-1 bg-white"
+                      placeholder="Recipe link"
+                    />
+                  )}
+                />
+              </View>
+              <FieldError
+                message={
+                  form.formState.errors.link?.message ??
+                  form.formState.errors.recipe?.servings?.message
+                }
+              />
+            </View>
 
             <EditorTags form={form} />
 
@@ -298,7 +321,6 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
               <Button
                 variant="secondary"
                 className="mt-4 w-full"
-                textClassName="font-serif text-primary"
                 onPress={() => parts.append(emptyPart())}
               >
                 <Plus size={17} color={colors.primary} />
@@ -487,11 +509,9 @@ function PartEditor({
                   name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.amount`}
                   render={({ field }) => (
                     <Input
-                      value={field.value === null ? "" : String(field.value)}
+                      value={field.value}
                       onBlur={field.onBlur}
-                      onChangeText={(value) =>
-                        field.onChange(value === "" ? null : Number(value))
-                      }
+                      onChangeText={field.onChange}
                       accessibilityLabel={`Ingredient ${ingredientIndex + 1} amount`}
                       keyboardType="decimal-pad"
                       className="h-10 w-[52px] bg-white px-1 text-center font-bold"
@@ -562,10 +582,14 @@ function PartEditor({
                 <View className="mt-2 gap-2">
                   {suggestions.length > 0 && (
                     <View className="border-border overflow-hidden rounded-md border bg-white">
-                      {suggestions.map((suggestion) => (
+                      {suggestions.map((suggestion, suggestionIndex) => (
                         <Pressable
                           key={suggestion}
-                          className="border-b border-[hsl(40,15%,92%)] px-3 py-2.5 last:border-b-0"
+                          className={cn(
+                            "px-3 py-2.5",
+                            suggestionIndex < suggestions.length - 1 &&
+                              "border-b border-[hsl(40,15%,92%)]",
+                          )}
                           onPress={() => {
                             form.setValue(
                               `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`,
@@ -666,7 +690,7 @@ function PartEditor({
           label="Add ingredient"
           onPress={() =>
             ingredients.append({
-              amount: null,
+              amount: "",
               unit: null,
               name: "",
               note: "",

--- a/apps/mobile/src/components/dinners/RecipeEditor.tsx
+++ b/apps/mobile/src/components/dinners/RecipeEditor.tsx
@@ -478,9 +478,6 @@ function PartEditor({
       <View className="mt-1">
         {ingredients.fields.map((ingredient, ingredientIndex) => {
           const isExpanded = expandedId === ingredient.id;
-          const note = form.watch(
-            `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.note`,
-          );
           const name = form.watch(
             `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`,
           );
@@ -574,15 +571,9 @@ function PartEditor({
                   onPress={() => toggle(ingredient.id)}
                 >
                   {isExpanded ? (
-                    <ChevronDown
-                      size={19}
-                      color={note ? colors.primary : colors.mutedForeground}
-                    />
+                    <ChevronDown size={19} color={colors.mutedForeground} />
                   ) : (
-                    <ChevronRight
-                      size={19}
-                      color={note ? colors.primary : colors.mutedForeground}
-                    />
+                    <ChevronRight size={19} color={colors.mutedForeground} />
                   )}
                 </Pressable>
               </View>

--- a/apps/mobile/src/components/dinners/RecipeEditor.tsx
+++ b/apps/mobile/src/components/dinners/RecipeEditor.tsx
@@ -196,106 +196,114 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
           }}
         >
           <View className="gap-5">
-            <View className="gap-1.5">
-              <FieldLabel>Name</FieldLabel>
-              <Controller
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <Input
-                    value={field.value}
-                    onBlur={field.onBlur}
-                    onChangeText={field.onChange}
-                    accessibilityLabel="Dinner name"
-                    className="h-12 bg-white text-lg font-semibold"
-                  />
-                )}
-              />
-              <FieldError message={form.formState.errors.name?.message} />
-            </View>
+            <View className="gap-4">
+              <View className="gap-1.5">
+                <FieldLabel>Name</FieldLabel>
+                <Controller
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <Input
+                      value={field.value}
+                      onBlur={field.onBlur}
+                      onChangeText={field.onChange}
+                      accessibilityLabel="Dinner name"
+                      className="h-12 bg-white text-lg font-semibold"
+                    />
+                  )}
+                />
+                <FieldError message={form.formState.errors.name?.message} />
+              </View>
 
-            <View>
-              <View className="flex-row gap-2">
-                <View className="gap-1.5">
-                  <FieldLabel>Servings</FieldLabel>
-                  <View className="border-border h-11 w-[116px] flex-row overflow-hidden rounded-md border bg-white">
-                    <Pressable
-                      accessibilityLabel="Decrease servings"
-                      className="border-border w-9 items-center justify-center border-r"
-                      onPress={() =>
-                        form.setValue(
-                          "recipe.servings",
-                          Math.max(1, (servings ?? 2) - 1),
-                          { shouldDirty: true },
-                        )
-                      }
-                    >
-                      <Minus size={16} color={colors.mutedForeground} />
-                    </Pressable>
+              <View>
+                <View className="flex-row gap-2">
+                  <View className="gap-1.5">
+                    <FieldLabel>Servings</FieldLabel>
+                    <View className="border-border h-11 w-[116px] flex-row overflow-hidden rounded-md border bg-white">
+                      <Pressable
+                        accessibilityLabel="Decrease servings"
+                        className="border-border w-9 items-center justify-center border-r"
+                        onPress={() =>
+                          form.setValue(
+                            "recipe.servings",
+                            Math.max(1, (servings ?? 2) - 1),
+                            { shouldDirty: true },
+                          )
+                        }
+                      >
+                        <Minus size={16} color={colors.mutedForeground} />
+                      </Pressable>
+                      <Controller
+                        control={form.control}
+                        name="recipe.servings"
+                        render={({ field }) => (
+                          <Input
+                            value={
+                              field.value === null ? "" : String(field.value)
+                            }
+                            onBlur={field.onBlur}
+                            onChangeText={(value) =>
+                              field.onChange(
+                                value === "" ? null : Number(value),
+                              )
+                            }
+                            accessibilityLabel="Number of servings"
+                            keyboardType="number-pad"
+                            textAlign="center"
+                            className="min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 py-0 font-bold"
+                            placeholder="–"
+                          />
+                        )}
+                      />
+                      <Pressable
+                        accessibilityLabel="Increase servings"
+                        className="border-border w-9 items-center justify-center border-l"
+                        onPress={() =>
+                          form.setValue(
+                            "recipe.servings",
+                            (servings ?? 0) + 1,
+                            {
+                              shouldDirty: true,
+                            },
+                          )
+                        }
+                      >
+                        <Plus size={16} color={colors.mutedForeground} />
+                      </Pressable>
+                    </View>
+                  </View>
+
+                  <View className="min-w-0 flex-1 gap-1.5">
+                    <FieldLabel>Recipe link</FieldLabel>
                     <Controller
                       control={form.control}
-                      name="recipe.servings"
+                      name="link"
                       render={({ field }) => (
                         <Input
-                          value={
-                            field.value === null ? "" : String(field.value)
-                          }
+                          value={field.value}
                           onBlur={field.onBlur}
-                          onChangeText={(value) =>
-                            field.onChange(value === "" ? null : Number(value))
-                          }
-                          accessibilityLabel="Number of servings"
-                          keyboardType="number-pad"
-                          textAlign="center"
-                          className="min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 py-0 font-bold"
-                          placeholder="–"
+                          onChangeText={field.onChange}
+                          accessibilityLabel="Recipe link"
+                          autoCapitalize="none"
+                          keyboardType="url"
+                          className="h-11 bg-white"
                         />
                       )}
                     />
-                    <Pressable
-                      accessibilityLabel="Increase servings"
-                      className="border-border w-9 items-center justify-center border-l"
-                      onPress={() =>
-                        form.setValue("recipe.servings", (servings ?? 0) + 1, {
-                          shouldDirty: true,
-                        })
-                      }
-                    >
-                      <Plus size={16} color={colors.mutedForeground} />
-                    </Pressable>
                   </View>
                 </View>
-
-                <View className="min-w-0 flex-1 gap-1.5">
-                  <FieldLabel>Recipe link</FieldLabel>
-                  <Controller
-                    control={form.control}
-                    name="link"
-                    render={({ field }) => (
-                      <Input
-                        value={field.value}
-                        onBlur={field.onBlur}
-                        onChangeText={field.onChange}
-                        accessibilityLabel="Recipe link"
-                        autoCapitalize="none"
-                        keyboardType="url"
-                        className="h-11 bg-white"
-                      />
-                    )}
-                  />
-                </View>
+                <FieldError
+                  message={
+                    form.formState.errors.link?.message ??
+                    form.formState.errors.recipe?.servings?.message
+                  }
+                />
               </View>
-              <FieldError
-                message={
-                  form.formState.errors.link?.message ??
-                  form.formState.errors.recipe?.servings?.message
-                }
-              />
-            </View>
 
-            <View className="gap-1.5">
-              <FieldLabel>Tags</FieldLabel>
-              <EditorTags form={form} />
+              <View className="gap-1.5">
+                <FieldLabel>Tags</FieldLabel>
+                <EditorTags form={form} />
+              </View>
             </View>
 
             <View className="border-t border-[hsl(40,15%,86%)] pt-5">
@@ -388,7 +396,9 @@ function PartEditor({
     control: form.control,
     name: `recipe.parts.${partIndex}.steps`,
   });
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  // Only one row is expanded at a time, so focusing or expanding another
+  // row contracts the previous one.
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const [focusedIngredient, setFocusedIngredient] = useState<string | null>(
     null,
   );
@@ -405,20 +415,14 @@ function PartEditor({
 
     const newIds = ids.filter((id) => !knownIds.current?.has(id));
     if (newIds.length > 0) {
-      setExpanded((current) => new Set([...current, ...newIds]));
+      setExpandedId(newIds[newIds.length - 1] ?? null);
     }
     knownIds.current = new Set(ids);
   }, [ingredients.fields, steps.fields]);
 
-  const open = (id: string) =>
-    setExpanded((current) => new Set(current).add(id));
+  const open = (id: string) => setExpandedId(id);
   const toggle = (id: string) =>
-    setExpanded((current) => {
-      const next = new Set(current);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+    setExpandedId((current) => (current === id ? null : id));
 
   return (
     <View
@@ -471,9 +475,9 @@ function PartEditor({
 
       <SectionLabel>Ingredients</SectionLabel>
 
-      <View className="mt-2">
+      <View className="mt-1">
         {ingredients.fields.map((ingredient, ingredientIndex) => {
-          const isExpanded = expanded.has(ingredient.id);
+          const isExpanded = expandedId === ingredient.id;
           const note = form.watch(
             `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.note`,
           );
@@ -499,7 +503,7 @@ function PartEditor({
             <View
               key={ingredient.id}
               className={cn(
-                "border-b border-[hsl(40,15%,92%)] px-1 py-2",
+                "border-b border-[hsl(40,15%,92%)] px-1 py-1.5",
                 isExpanded &&
                   "rounded-[10px] border border-[hsl(18,60%,80%)] bg-[hsl(40,33%,95%)]",
               )}
@@ -512,6 +516,7 @@ function PartEditor({
                     <Input
                       value={field.value}
                       onBlur={field.onBlur}
+                      onFocus={() => open(ingredient.id)}
                       onChangeText={field.onChange}
                       accessibilityLabel={`Ingredient ${ingredientIndex + 1} amount`}
                       keyboardType="decimal-pad"
@@ -704,9 +709,9 @@ function PartEditor({
 
       <View className="mt-5">
         <SectionLabel>Steps</SectionLabel>
-        <View className="mt-2">
+        <View className="mt-1">
           {steps.fields.map((step, stepIndex) => {
-            const isExpanded = expanded.has(step.id);
+            const isExpanded = expandedId === step.id;
             const stepError =
               form.formState.errors.recipe?.parts?.[partIndex]?.steps?.[
                 stepIndex
@@ -716,7 +721,7 @@ function PartEditor({
               <View
                 key={step.id}
                 className={cn(
-                  "border-b border-[hsl(40,15%,92%)] px-1 py-2",
+                  "border-b border-[hsl(40,15%,92%)] px-1 py-1.5",
                   isExpanded &&
                     "rounded-[10px] border border-[hsl(18,60%,80%)] bg-[hsl(40,33%,95%)]",
                 )}
@@ -741,6 +746,19 @@ function PartEditor({
                       />
                     )}
                   />
+                  <Pressable
+                    accessibilityLabel={
+                      isExpanded ? "Hide step controls" : "Show step controls"
+                    }
+                    className="h-10 w-[30px] items-center justify-center"
+                    onPress={() => toggle(step.id)}
+                  >
+                    {isExpanded ? (
+                      <ChevronDown size={19} color={colors.mutedForeground} />
+                    ) : (
+                      <ChevronRight size={19} color={colors.mutedForeground} />
+                    )}
+                  </Pressable>
                 </View>
                 {isExpanded && (
                   <View className="ml-[26px] mt-2">

--- a/apps/mobile/src/components/dinners/RecipeEditor.tsx
+++ b/apps/mobile/src/components/dinners/RecipeEditor.tsx
@@ -434,7 +434,7 @@ function PartEditor({
     >
       {multiMode && (
         <View className="mb-4 gap-1.5">
-          <FieldLabel>Part name</FieldLabel>
+          <FieldLabel>Part</FieldLabel>
           <View className="flex-row items-center gap-2">
             <Controller
               control={form.control}

--- a/apps/mobile/src/components/dinners/RecipeEditor.tsx
+++ b/apps/mobile/src/components/dinners/RecipeEditor.tsx
@@ -1,0 +1,950 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  Minus,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react-native";
+import { format } from "date-fns";
+import { useNavigation, usePreventRemove } from "@react-navigation/native";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Controller,
+  type UseFormReturn,
+  useFieldArray,
+  useForm,
+} from "react-hook-form";
+import {
+  UNITS,
+  type DinnerWithRecipe,
+  recipeIngredientSchema,
+} from "@planeatrepeat/shared";
+import { api } from "../../utils/api";
+import { colors } from "../../theme/colors";
+import { cn } from "../../utils/cn";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { Textarea } from "../ui/Textarea";
+
+const editorIngredientSchema = recipeIngredientSchema.extend({
+  name: z.string().trim().min(1, "Name required"),
+  amount: z.number().positive("Amount must be more than 0").nullable(),
+  note: z.string(),
+});
+
+const recipeEditorSchema = z.object({
+  name: z.string().trim().min(1, "Add a dinner name"),
+  tags: z.array(z.string()),
+  newTag: z.string().optional(),
+  link: z.union([z.literal(""), z.string().url("Enter a valid URL")]),
+  notes: z.string(),
+  recipe: z.object({
+    servings: z.number().int().positive().nullable(),
+    parts: z.array(
+      z.object({
+        name: z.string(),
+        ingredients: z.array(editorIngredientSchema),
+        steps: z.array(
+          z.object({
+            text: z.string().trim().min(1, "Add a step or remove this row"),
+          }),
+        ),
+      }),
+    ),
+  }),
+});
+
+export type RecipeEditorValues = z.infer<typeof recipeEditorSchema>;
+
+export type RecipeEditorHandle = {
+  cancel: () => void;
+  submit: () => void;
+};
+
+type Props = {
+  dinner: DinnerWithRecipe;
+  isPending: boolean;
+  onCancel: () => void;
+  onSave: (values: RecipeEditorValues) => void;
+  onDelete: () => void;
+};
+
+const emptyPart = (): RecipeEditorValues["recipe"]["parts"][number] => ({
+  name: "",
+  ingredients: [],
+  steps: [],
+});
+
+export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
+  function RecipeEditor(
+    { dinner, isPending, onCancel, onSave, onDelete },
+    ref,
+  ) {
+    const form = useForm<RecipeEditorValues>({
+      resolver: zodResolver(recipeEditorSchema),
+      defaultValues: {
+        name: dinner.name,
+        tags: dinner.tags.map((tag) => tag.value),
+        newTag: "",
+        link: dinner.link ?? "",
+        notes: dinner.notes ?? "",
+        recipe: {
+          servings: dinner.servings,
+          parts: dinner.parts.map((part) => ({
+            name: part.name ?? "",
+            ingredients: part.ingredients.map((ingredient) => ({
+              name: ingredient.name,
+              amount: ingredient.amount,
+              unit: UNITS.find((unit) => unit === ingredient.unit) ?? null,
+              note: ingredient.note ?? "",
+            })),
+            steps: part.steps.map((step) => ({ text: step.text })),
+          })),
+        },
+      },
+    });
+    const parts = useFieldArray({
+      control: form.control,
+      name: "recipe.parts",
+    });
+    const watchedParts = form.watch("recipe.parts");
+    const servings = form.watch("recipe.servings");
+    const navigation = useNavigation();
+    const multiMode =
+      watchedParts.length > 1 ||
+      watchedParts.some((part) => part.name.trim().length > 0);
+    const ingredientNamesQuery = api.dinner.ingredientNames.useQuery();
+
+    usePreventRemove(form.formState.isDirty, ({ data }) => {
+      Alert.alert(
+        "Discard changes?",
+        "Your unsaved recipe changes will be lost.",
+        [
+          { text: "Keep editing", style: "cancel" },
+          {
+            text: "Discard",
+            style: "destructive",
+            onPress: () => navigation.dispatch(data.action),
+          },
+        ],
+      );
+    });
+
+    const cancel = () => {
+      if (!form.formState.isDirty) {
+        onCancel();
+        return;
+      }
+
+      Alert.alert(
+        "Discard changes?",
+        "Your unsaved recipe changes will be lost.",
+        [
+          { text: "Keep editing", style: "cancel" },
+          { text: "Discard", style: "destructive", onPress: onCancel },
+        ],
+      );
+    };
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        cancel,
+        submit: () => void form.handleSubmit(onSave)(),
+      }),
+      [form, onSave],
+    );
+
+    return (
+      <KeyboardAvoidingView
+        className="bg-background flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 92 : 0}
+      >
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{
+            paddingHorizontal: 16,
+            paddingTop: 12,
+            paddingBottom: 48,
+          }}
+        >
+          <View className="gap-5">
+            <Controller
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Input
+                  value={field.value}
+                  onBlur={field.onBlur}
+                  onChangeText={field.onChange}
+                  accessibilityLabel="Dinner name"
+                  className="h-12 bg-white text-lg font-semibold"
+                  placeholder="Dinner name"
+                />
+              )}
+            />
+            <FieldError message={form.formState.errors.name?.message} />
+
+            <View className="flex-row gap-2">
+              <View className="border-border h-11 w-[116px] flex-row overflow-hidden rounded-md border bg-white">
+                <Pressable
+                  accessibilityLabel="Decrease servings"
+                  className="border-border w-9 items-center justify-center border-r"
+                  onPress={() =>
+                    form.setValue(
+                      "recipe.servings",
+                      Math.max(1, (servings ?? 2) - 1),
+                      { shouldDirty: true },
+                    )
+                  }
+                >
+                  <Minus size={16} color={colors.mutedForeground} />
+                </Pressable>
+                <Controller
+                  control={form.control}
+                  name="recipe.servings"
+                  render={({ field }) => (
+                    <Input
+                      value={field.value === null ? "" : String(field.value)}
+                      onBlur={field.onBlur}
+                      onChangeText={(value) =>
+                        field.onChange(value === "" ? null : Number(value))
+                      }
+                      accessibilityLabel="Number of servings"
+                      keyboardType="number-pad"
+                      className="min-w-0 flex-1 rounded-none border-0 bg-transparent px-1 text-center font-bold"
+                      placeholder="–"
+                    />
+                  )}
+                />
+                <Pressable
+                  accessibilityLabel="Increase servings"
+                  className="border-border w-9 items-center justify-center border-l"
+                  onPress={() =>
+                    form.setValue("recipe.servings", (servings ?? 0) + 1, {
+                      shouldDirty: true,
+                    })
+                  }
+                >
+                  <Plus size={16} color={colors.mutedForeground} />
+                </Pressable>
+              </View>
+
+              <Controller
+                control={form.control}
+                name="link"
+                render={({ field }) => (
+                  <Input
+                    value={field.value}
+                    onBlur={field.onBlur}
+                    onChangeText={field.onChange}
+                    accessibilityLabel="Recipe link"
+                    autoCapitalize="none"
+                    keyboardType="url"
+                    className="h-11 min-w-0 flex-1 bg-white"
+                    placeholder="Recipe link"
+                  />
+                )}
+              />
+            </View>
+            <FieldError
+              message={
+                form.formState.errors.link?.message ??
+                form.formState.errors.recipe?.servings?.message
+              }
+            />
+
+            <EditorTags form={form} />
+
+            <View className="border-t border-[hsl(40,15%,86%)] pt-5">
+              {parts.fields.map((part, partIndex) => (
+                <PartEditor
+                  key={part.id}
+                  form={form}
+                  partIndex={partIndex}
+                  multiMode={multiMode}
+                  ingredientNames={
+                    ingredientNamesQuery.data?.ingredientNames ?? []
+                  }
+                  canMoveUp={partIndex > 0}
+                  canMoveDown={partIndex < parts.fields.length - 1}
+                  onMoveUp={() => parts.move(partIndex, partIndex - 1)}
+                  onMoveDown={() => parts.move(partIndex, partIndex + 1)}
+                  onRemove={() => parts.remove(partIndex)}
+                />
+              ))}
+
+              <Button
+                variant="secondary"
+                className="mt-4 w-full"
+                textClassName="font-serif text-primary"
+                onPress={() => parts.append(emptyPart())}
+              >
+                <Plus size={17} color={colors.primary} />
+                <Text className="text-primary font-serif text-sm">
+                  {parts.fields.length === 0 ? "Add recipe" : "Add part"}
+                </Text>
+              </Button>
+            </View>
+
+            <View className="gap-2 border-t border-[hsl(40,15%,86%)] pt-5">
+              <Text className="text-foreground font-serif text-base">Tips</Text>
+              <Controller
+                control={form.control}
+                name="notes"
+                render={({ field }) => (
+                  <Textarea
+                    value={field.value}
+                    onBlur={field.onBlur}
+                    onChangeText={field.onChange}
+                    className="min-h-24 bg-white text-[15px]"
+                    placeholder="Anything useful to remember next time"
+                  />
+                )}
+              />
+            </View>
+
+            <DeleteDinnerButton
+              dinnerId={dinner.id}
+              isPending={isPending}
+              onDelete={onDelete}
+            />
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    );
+  },
+);
+
+type PartEditorProps = {
+  form: UseFormReturn<RecipeEditorValues>;
+  partIndex: number;
+  multiMode: boolean;
+  ingredientNames: string[];
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+};
+
+function PartEditor({
+  form,
+  partIndex,
+  multiMode,
+  ingredientNames,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+}: PartEditorProps) {
+  const ingredients = useFieldArray({
+    control: form.control,
+    name: `recipe.parts.${partIndex}.ingredients`,
+  });
+  const steps = useFieldArray({
+    control: form.control,
+    name: `recipe.parts.${partIndex}.steps`,
+  });
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [focusedIngredient, setFocusedIngredient] = useState<string | null>(
+    null,
+  );
+  const knownIds = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    const ids = [...ingredients.fields, ...steps.fields].map(
+      (field) => field.id,
+    );
+    if (knownIds.current === null) {
+      knownIds.current = new Set(ids);
+      return;
+    }
+
+    const newIds = ids.filter((id) => !knownIds.current?.has(id));
+    if (newIds.length > 0) {
+      setExpanded((current) => new Set([...current, ...newIds]));
+    }
+    knownIds.current = new Set(ids);
+  }, [ingredients.fields, steps.fields]);
+
+  const open = (id: string) =>
+    setExpanded((current) => new Set(current).add(id));
+  const toggle = (id: string) =>
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  return (
+    <View
+      className={cn(
+        partIndex > 0 &&
+          multiMode &&
+          "mt-6 border-t border-[hsl(40,15%,86%)] pt-5",
+      )}
+    >
+      {multiMode ? (
+        <View className="mb-3 flex-row items-center gap-2">
+          <Controller
+            control={form.control}
+            name={`recipe.parts.${partIndex}.name`}
+            render={({ field }) => (
+              <Input
+                value={field.value}
+                onBlur={field.onBlur}
+                onChangeText={field.onChange}
+                accessibilityLabel={`Part ${partIndex + 1} name`}
+                className="h-11 min-w-0 flex-1 bg-white font-serif text-base"
+                placeholder="Part name (optional)"
+              />
+            )}
+          />
+          <View className="flex-row">
+            <IconButton
+              label="Move part up"
+              disabled={!canMoveUp}
+              onPress={onMoveUp}
+            >
+              <ArrowUp size={17} color={colors.mutedForeground} />
+            </IconButton>
+            <IconButton
+              label="Move part down"
+              disabled={!canMoveDown}
+              onPress={onMoveDown}
+            >
+              <ArrowDown size={17} color={colors.mutedForeground} />
+            </IconButton>
+            <IconButton label="Remove part" onPress={onRemove}>
+              <X size={18} color={colors.destructive} />
+            </IconButton>
+          </View>
+        </View>
+      ) : (
+        <SectionLabel>Ingredients</SectionLabel>
+      )}
+
+      <View className="mt-2">
+        {ingredients.fields.map((ingredient, ingredientIndex) => {
+          const isExpanded = expanded.has(ingredient.id);
+          const note = form.watch(
+            `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.note`,
+          );
+          const name = form.watch(
+            `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`,
+          );
+          const ingredientError =
+            form.formState.errors.recipe?.parts?.[partIndex]?.ingredients?.[
+              ingredientIndex
+            ];
+          const suggestions =
+            focusedIngredient === ingredient.id && name.trim().length > 0
+              ? ingredientNames
+                  .filter(
+                    (candidate) =>
+                      candidate.toLowerCase().includes(name.toLowerCase()) &&
+                      candidate.toLowerCase() !== name.toLowerCase(),
+                  )
+                  .slice(0, 5)
+              : [];
+
+          return (
+            <View
+              key={ingredient.id}
+              className={cn(
+                "border-b border-[hsl(40,15%,92%)] px-1 py-2",
+                isExpanded &&
+                  "rounded-[10px] border border-[hsl(18,60%,80%)] bg-[hsl(40,33%,95%)]",
+              )}
+            >
+              <View className="flex-row items-center gap-1.5">
+                <Controller
+                  control={form.control}
+                  name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.amount`}
+                  render={({ field }) => (
+                    <Input
+                      value={field.value === null ? "" : String(field.value)}
+                      onBlur={field.onBlur}
+                      onChangeText={(value) =>
+                        field.onChange(value === "" ? null : Number(value))
+                      }
+                      accessibilityLabel={`Ingredient ${ingredientIndex + 1} amount`}
+                      keyboardType="decimal-pad"
+                      className="h-10 w-[52px] bg-white px-1 text-center font-bold"
+                      placeholder="0"
+                    />
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.unit`}
+                  render={({ field }) => (
+                    <Pressable
+                      accessibilityLabel={`Ingredient ${ingredientIndex + 1} unit`}
+                      className="border-input h-10 w-[58px] items-center justify-center rounded-md border bg-white"
+                      onPress={() => open(ingredient.id)}
+                    >
+                      <Text className="text-foreground text-sm">
+                        {field.value ?? "–"}
+                      </Text>
+                    </Pressable>
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`}
+                  render={({ field }) => (
+                    <Input
+                      value={field.value}
+                      onBlur={() => {
+                        field.onBlur();
+                        setTimeout(() => setFocusedIngredient(null), 150);
+                      }}
+                      onFocus={() => {
+                        open(ingredient.id);
+                        setFocusedIngredient(ingredient.id);
+                      }}
+                      onChangeText={field.onChange}
+                      accessibilityLabel={`Ingredient ${ingredientIndex + 1} name`}
+                      className="h-10 min-w-0 flex-1 bg-white px-2"
+                      placeholder="Ingredient"
+                    />
+                  )}
+                />
+                <Pressable
+                  accessibilityLabel={
+                    isExpanded
+                      ? "Hide ingredient controls"
+                      : "Show ingredient controls"
+                  }
+                  className="h-10 w-[30px] items-center justify-center"
+                  onPress={() => toggle(ingredient.id)}
+                >
+                  {isExpanded ? (
+                    <ChevronDown
+                      size={19}
+                      color={note ? colors.primary : colors.mutedForeground}
+                    />
+                  ) : (
+                    <ChevronRight
+                      size={19}
+                      color={note ? colors.primary : colors.mutedForeground}
+                    />
+                  )}
+                </Pressable>
+              </View>
+
+              {isExpanded && (
+                <View className="mt-2 gap-2">
+                  {suggestions.length > 0 && (
+                    <View className="border-border overflow-hidden rounded-md border bg-white">
+                      {suggestions.map((suggestion) => (
+                        <Pressable
+                          key={suggestion}
+                          className="border-b border-[hsl(40,15%,92%)] px-3 py-2.5 last:border-b-0"
+                          onPress={() => {
+                            form.setValue(
+                              `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`,
+                              suggestion,
+                              { shouldDirty: true },
+                            );
+                            setFocusedIngredient(null);
+                          }}
+                        >
+                          <Text className="text-foreground text-sm">
+                            {suggestion}
+                          </Text>
+                        </Pressable>
+                      ))}
+                    </View>
+                  )}
+
+                  <Controller
+                    control={form.control}
+                    name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.unit`}
+                    render={({ field }) => (
+                      <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        keyboardShouldPersistTaps="handled"
+                        contentContainerStyle={{ gap: 6 }}
+                      >
+                        {[null, ...UNITS].map((unit) => {
+                          const selected = field.value === unit;
+                          return (
+                            <Pressable
+                              key={unit ?? "none"}
+                              accessibilityRole="radio"
+                              accessibilityState={{ selected }}
+                              className={cn(
+                                "border-border min-w-10 rounded-full border bg-white px-3 py-2",
+                                selected && "border-primary bg-primary/10",
+                              )}
+                              onPress={() => field.onChange(unit)}
+                            >
+                              <Text
+                                className={cn(
+                                  "text-muted-foreground text-center text-sm",
+                                  selected && "text-primary font-semibold",
+                                )}
+                              >
+                                {unit ?? "–"}
+                              </Text>
+                            </Pressable>
+                          );
+                        })}
+                      </ScrollView>
+                    )}
+                  />
+
+                  <Controller
+                    control={form.control}
+                    name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.note`}
+                    render={({ field }) => (
+                      <Input
+                        value={field.value}
+                        onBlur={field.onBlur}
+                        onChangeText={field.onChange}
+                        accessibilityLabel={`Ingredient ${ingredientIndex + 1} note`}
+                        className="h-10 bg-white text-sm"
+                        placeholder="note — e.g. grated, cut in strips"
+                      />
+                    )}
+                  />
+
+                  <RowControls
+                    canMoveUp={ingredientIndex > 0}
+                    canMoveDown={
+                      ingredientIndex < ingredients.fields.length - 1
+                    }
+                    onMoveUp={() =>
+                      ingredients.move(ingredientIndex, ingredientIndex - 1)
+                    }
+                    onMoveDown={() =>
+                      ingredients.move(ingredientIndex, ingredientIndex + 1)
+                    }
+                    onRemove={() => ingredients.remove(ingredientIndex)}
+                  />
+                </View>
+              )}
+              <FieldError
+                message={
+                  ingredientError?.name?.message ??
+                  ingredientError?.amount?.message ??
+                  ingredientError?.unit?.message
+                }
+              />
+            </View>
+          );
+        })}
+
+        <AddButton
+          label="Add ingredient"
+          onPress={() =>
+            ingredients.append({
+              amount: null,
+              unit: null,
+              name: "",
+              note: "",
+            })
+          }
+        />
+      </View>
+
+      <View className="mt-5">
+        <SectionLabel>Steps</SectionLabel>
+        <View className="mt-2">
+          {steps.fields.map((step, stepIndex) => {
+            const isExpanded = expanded.has(step.id);
+            const stepError =
+              form.formState.errors.recipe?.parts?.[partIndex]?.steps?.[
+                stepIndex
+              ]?.text?.message;
+
+            return (
+              <View
+                key={step.id}
+                className={cn(
+                  "border-b border-[hsl(40,15%,92%)] px-1 py-2",
+                  isExpanded &&
+                    "rounded-[10px] border border-[hsl(18,60%,80%)] bg-[hsl(40,33%,95%)]",
+                )}
+              >
+                <View className="flex-row gap-2">
+                  <Text className="w-[18px] pt-2 font-serif text-base text-[hsl(18,75%,50%)]">
+                    {stepIndex + 1}
+                  </Text>
+                  <Controller
+                    control={form.control}
+                    name={`recipe.parts.${partIndex}.steps.${stepIndex}.text`}
+                    render={({ field }) => (
+                      <Textarea
+                        value={field.value}
+                        onBlur={field.onBlur}
+                        onFocus={() => open(step.id)}
+                        onChangeText={field.onChange}
+                        accessibilityLabel={`Step ${stepIndex + 1}`}
+                        className="min-h-10 min-w-0 flex-1 bg-white py-2 text-[15px]"
+                        placeholder="Describe this step"
+                        scrollEnabled={false}
+                      />
+                    )}
+                  />
+                </View>
+                {isExpanded && (
+                  <View className="ml-[26px] mt-2">
+                    <RowControls
+                      canMoveUp={stepIndex > 0}
+                      canMoveDown={stepIndex < steps.fields.length - 1}
+                      onMoveUp={() => steps.move(stepIndex, stepIndex - 1)}
+                      onMoveDown={() => steps.move(stepIndex, stepIndex + 1)}
+                      onRemove={() => steps.remove(stepIndex)}
+                    />
+                  </View>
+                )}
+                <View className="ml-[26px]">
+                  <FieldError message={stepError} />
+                </View>
+              </View>
+            );
+          })}
+          <AddButton
+            label="Add step"
+            onPress={() => steps.append({ text: "" })}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function EditorTags({ form }: { form: UseFormReturn<RecipeEditorValues> }) {
+  const [tagInput, setTagInput] = useState("");
+  const tagsQuery = api.dinner.tags.useQuery(undefined, {
+    select: (data) => data.tags.map((tag) => tag.value),
+  });
+  const selected = form.watch("tags");
+
+  const addTag = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed || selected.includes(trimmed)) return;
+    form.setValue("tags", [...selected, trimmed], { shouldDirty: true });
+    setTagInput("");
+  };
+
+  return (
+    <View className="gap-2">
+      <View className="flex-row flex-wrap gap-2">
+        {selected.map((tag) => (
+          <Pressable
+            key={tag}
+            accessibilityLabel={`Remove ${tag} tag`}
+            className="bg-secondary flex-row items-center gap-1 rounded-full px-2.5 py-1.5"
+            onPress={() =>
+              form.setValue(
+                "tags",
+                selected.filter((candidate) => candidate !== tag),
+                { shouldDirty: true },
+              )
+            }
+          >
+            <Text className="text-secondary-foreground text-xs font-semibold">
+              {tag}
+            </Text>
+            <X size={12} color={colors.mutedForeground} />
+          </Pressable>
+        ))}
+        <Input
+          value={tagInput}
+          onChangeText={setTagInput}
+          onSubmitEditing={() => addTag(tagInput)}
+          returnKeyType="done"
+          className="h-9 min-w-[116px] flex-1 border-dashed bg-white"
+          placeholder="Add tag…"
+        />
+      </View>
+
+      {!!tagsQuery.data?.length && tagInput.length > 0 && (
+        <View className="flex-row flex-wrap gap-2">
+          {tagsQuery.data
+            .filter(
+              (tag) =>
+                tag.toLowerCase().includes(tagInput.toLowerCase()) &&
+                !selected.includes(tag),
+            )
+            .slice(0, 5)
+            .map((tag) => (
+              <Pressable
+                key={tag}
+                className="border-border rounded-full border bg-white px-2.5 py-1.5"
+                onPress={() => addTag(tag)}
+              >
+                <Text className="text-muted-foreground text-xs">{tag}</Text>
+              </Pressable>
+            ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function DeleteDinnerButton({
+  dinnerId,
+  isPending,
+  onDelete,
+}: {
+  dinnerId: number;
+  isPending: boolean;
+  onDelete: () => void;
+}) {
+  const plansQuery = api.plan.plansForDinner.useQuery(
+    { dinnerId },
+    { enabled: false },
+  );
+
+  const confirmDelete = async () => {
+    const result = await plansQuery.refetch();
+    const dates =
+      result.data?.plans.map((plan) => format(plan.date, "MMMM do, y")) ?? [];
+    const affected =
+      dates.length > 0
+        ? `\n\nPlans on these dates will also be deleted:\n${dates.join("\n")}`
+        : "";
+
+    Alert.alert(
+      "Delete dinner",
+      `Are you sure? This cannot be undone.${affected}`,
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Delete", style: "destructive", onPress: onDelete },
+      ],
+    );
+  };
+
+  return (
+    <Button
+      variant="outline"
+      disabled={isPending || plansQuery.isFetching}
+      className="w-full border-[hsl(0,50%,85%)]"
+      onPress={() => void confirmDelete()}
+    >
+      <Trash2 size={17} color="hsl(0, 60%, 48%)" />
+      <Text className="text-sm font-semibold text-[hsl(0,60%,48%)]">
+        Delete dinner
+      </Text>
+    </Button>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Text className="text-muted-foreground text-[11px] font-bold uppercase tracking-[1px]">
+      {children}
+    </Text>
+  );
+}
+
+function AddButton({ label, onPress }: { label: string; onPress: () => void }) {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="mt-2 w-full border-dashed border-[hsl(40,15%,80%)] bg-transparent"
+      onPress={onPress}
+    >
+      <Plus size={16} color={colors.primary} />
+      <Text className="text-primary text-sm font-medium">{label}</Text>
+    </Button>
+  );
+}
+
+function IconButton({
+  label,
+  children,
+  disabled,
+  onPress,
+}: {
+  label: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel={label}
+      disabled={disabled}
+      className={cn(
+        "h-10 w-9 items-center justify-center rounded-md",
+        disabled && "opacity-30",
+      )}
+      onPress={onPress}
+    >
+      {children}
+    </Pressable>
+  );
+}
+
+function RowControls({
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+}: {
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <View className="flex-row">
+        <IconButton label="Move up" disabled={!canMoveUp} onPress={onMoveUp}>
+          <ArrowUp size={17} color={colors.mutedForeground} />
+        </IconButton>
+        <IconButton
+          label="Move down"
+          disabled={!canMoveDown}
+          onPress={onMoveDown}
+        >
+          <ArrowDown size={17} color={colors.mutedForeground} />
+        </IconButton>
+      </View>
+      <Pressable className="px-2 py-2" onPress={onRemove}>
+        <Text className="text-destructive text-sm font-semibold">Remove</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return (
+    <Text className="text-destructive mt-1 text-xs font-medium">{message}</Text>
+  );
+}

--- a/apps/mobile/src/components/dinners/RecipeEditor.tsx
+++ b/apps/mobile/src/components/dinners/RecipeEditor.tsx
@@ -154,7 +154,9 @@ export const RecipeEditor = forwardRef<RecipeEditorHandle, Props>(
       watchedParts.some((part) => part.name.trim().length > 0);
     const ingredientNamesQuery = api.dinner.ingredientNames.useQuery();
 
-    usePreventRemove(form.formState.isDirty, ({ data }) => {
+    // Disarm the guard while a save/delete is in flight so the goBack after a
+    // successful delete isn't intercepted by the discard prompt.
+    usePreventRemove(form.formState.isDirty && !isPending, ({ data }) => {
       Alert.alert(
         "Discard changes?",
         "Your unsaved recipe changes will be lost.",

--- a/apps/mobile/src/components/dinners/RecipeView.tsx
+++ b/apps/mobile/src/components/dinners/RecipeView.tsx
@@ -1,0 +1,176 @@
+import { Linking, Pressable, ScrollView, Text, View } from "react-native";
+import { ExternalLink } from "lucide-react-native";
+import { formatAmount, type DinnerWithRecipe } from "@planeatrepeat/shared";
+import { Button } from "../ui/Button";
+
+type Props = {
+  dinner: DinnerWithRecipe;
+  onEdit: () => void;
+};
+
+const sourceLabel = (link: string) => {
+  try {
+    return new URL(link).hostname.replace(/^www\./, "");
+  } catch {
+    return link;
+  }
+};
+
+export function RecipeView({ dinner, onEdit }: Props) {
+  const hasRecipe = dinner.parts.length > 0;
+
+  return (
+    <ScrollView
+      className="bg-background flex-1"
+      contentContainerStyle={{
+        paddingHorizontal: 20,
+        paddingTop: 12,
+        paddingBottom: 40,
+      }}
+    >
+      <View className="gap-3">
+        <Text
+          className="text-foreground font-serif text-[26px] leading-[31px]"
+          selectable
+        >
+          {dinner.name}
+        </Text>
+
+        {dinner.tags.length > 0 && (
+          <View className="flex-row flex-wrap gap-1.5">
+            {dinner.tags.map((tag) => (
+              <View
+                key={tag.value}
+                className="border-border rounded-full border bg-white px-2.5 py-[3px]"
+              >
+                <Text className="text-muted-foreground text-xs font-semibold">
+                  {tag.value}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {(dinner.link !== null || dinner.servings !== null) && (
+          <View className="flex-row flex-wrap items-center gap-2">
+            {dinner.link && (
+              <Pressable
+                accessibilityRole="link"
+                onPress={() => void Linking.openURL(dinner.link ?? "")}
+                className="flex-row items-center gap-1 py-1"
+              >
+                <Text className="text-sm font-semibold text-[hsl(18,75%,45%)]">
+                  {sourceLabel(dinner.link)}
+                </Text>
+                <ExternalLink size={14} color="hsl(18, 75%, 45%)" />
+              </Pressable>
+            )}
+            {dinner.link && dinner.servings && (
+              <Text className="text-[hsl(40,15%,78%)]">·</Text>
+            )}
+            {dinner.servings && (
+              <Text className="text-muted-foreground text-sm font-medium">
+                {dinner.servings} servings
+              </Text>
+            )}
+          </View>
+        )}
+      </View>
+
+      {hasRecipe ? (
+        <View className="mt-6">
+          {dinner.parts.map((part, partIndex) => (
+            <View
+              key={part.id}
+              className={
+                partIndex > 0
+                  ? "mt-[26px] border-t border-[hsl(40,15%,86%)]"
+                  : undefined
+              }
+            >
+              {part.name && (
+                <Text className="text-foreground mt-[22px] font-serif text-xl">
+                  {part.name}
+                </Text>
+              )}
+
+              {part.ingredients.length > 0 && (
+                <View className={part.name ? "mt-2.5" : undefined}>
+                  {part.ingredients.map((ingredient) => {
+                    const amount = [
+                      ingredient.amount === null
+                        ? ""
+                        : formatAmount(ingredient.amount),
+                      ingredient.unit ?? "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ");
+
+                    return (
+                      <View
+                        key={ingredient.id}
+                        className="flex-row gap-2.5 py-0.5"
+                      >
+                        <Text className="text-foreground w-[74px] text-base font-bold leading-[21px]">
+                          {amount}
+                        </Text>
+                        <Text className="text-foreground min-w-0 flex-1 text-base font-medium leading-[21px]">
+                          {ingredient.name}
+                          {ingredient.note && (
+                            <Text className="text-muted-foreground font-normal">
+                              {" "}
+                              — {ingredient.note}
+                            </Text>
+                          )}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              )}
+
+              {part.steps.length > 0 && (
+                <View className="mt-3 gap-[5px]">
+                  {part.steps.map((step, stepIndex) => (
+                    <View key={step.id} className="flex-row gap-2">
+                      <Text className="w-[22px] font-serif text-base leading-[22px] text-[hsl(18,75%,50%)]">
+                        {stepIndex + 1}
+                      </Text>
+                      <Text className="text-foreground min-w-0 flex-1 text-base font-medium leading-[22px]">
+                        {step.text}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              )}
+            </View>
+          ))}
+        </View>
+      ) : (
+        <View className="mt-8 items-start">
+          <Button onPress={onEdit}>Add recipe</Button>
+        </View>
+      )}
+
+      {dinner.notes && (
+        <View className="mt-[26px] border-t border-[hsl(40,15%,86%)]">
+          <Text className="text-foreground mb-1.5 mt-5 font-serif text-base">
+            Tips
+          </Text>
+          <Text
+            className="text-[15px] font-medium leading-[23px] text-[hsl(24,10%,25%)]"
+            selectable
+          >
+            {dinner.notes}
+          </Text>
+        </View>
+      )}
+
+      {!hasRecipe && !dinner.notes && (
+        <Text className="text-muted-foreground mt-5 text-sm">
+          Add ingredients and steps whenever you’re ready.
+        </Text>
+      )}
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/components/dinners/RecipeView.tsx
+++ b/apps/mobile/src/components/dinners/RecipeView.tsx
@@ -79,41 +79,56 @@ export function RecipeView({ dinner, onEdit }: Props) {
 
       {hasRecipe ? (
         <View className="mt-6">
-          {dinner.parts.map((part, partIndex) => (
-            <View
-              key={part.id}
-              className={
-                partIndex > 0
-                  ? "mt-[26px] border-t border-[hsl(40,15%,86%)]"
-                  : undefined
-              }
-            >
-              {part.name && (
-                <Text className="text-foreground mt-[22px] font-serif text-xl">
-                  {part.name}
-                </Text>
-              )}
+          {dinner.parts.map((part, partIndex) => {
+            const amounts = part.ingredients.map((ingredient) =>
+              [
+                ingredient.amount === null
+                  ? ""
+                  : formatAmount(ingredient.amount),
+                ingredient.unit ?? "",
+              ]
+                .filter(Boolean)
+                .join(" "),
+            );
+            // Size the amount column to the part's longest amount so short
+            // amounts sit close to the names; drop the column entirely when
+            // no ingredient in the part has one.
+            const longestAmount = Math.max(
+              0,
+              ...amounts.map((amount) => amount.length),
+            );
+            const amountWidth = Math.min(104, Math.ceil(longestAmount * 9.5));
 
-              {part.ingredients.length > 0 && (
-                <View className={part.name ? "mt-2.5" : undefined}>
-                  {part.ingredients.map((ingredient) => {
-                    const amount = [
-                      ingredient.amount === null
-                        ? ""
-                        : formatAmount(ingredient.amount),
-                      ingredient.unit ?? "",
-                    ]
-                      .filter(Boolean)
-                      .join(" ");
+            return (
+              <View
+                key={part.id}
+                className={
+                  partIndex > 0
+                    ? "mt-[26px] border-t border-[hsl(40,15%,86%)] pt-5"
+                    : undefined
+                }
+              >
+                {part.name && (
+                  <Text className="text-foreground font-serif text-xl">
+                    {part.name}
+                  </Text>
+                )}
 
-                    return (
+                {part.ingredients.length > 0 && (
+                  <View className={part.name ? "mt-2.5" : undefined}>
+                    {part.ingredients.map((ingredient, ingredientIndex) => (
                       <View
                         key={ingredient.id}
                         className="flex-row gap-2.5 py-0.5"
                       >
-                        <Text className="text-foreground w-[74px] text-base font-bold leading-[21px]">
-                          {amount}
-                        </Text>
+                        {amountWidth > 0 && (
+                          <Text
+                            className="text-foreground text-base font-bold leading-[21px]"
+                            style={{ width: amountWidth }}
+                          >
+                            {amounts[ingredientIndex]}
+                          </Text>
+                        )}
                         <Text className="text-foreground min-w-0 flex-1 text-base font-medium leading-[21px]">
                           {ingredient.name}
                           {ingredient.note && (
@@ -124,27 +139,27 @@ export function RecipeView({ dinner, onEdit }: Props) {
                           )}
                         </Text>
                       </View>
-                    );
-                  })}
-                </View>
-              )}
+                    ))}
+                  </View>
+                )}
 
-              {part.steps.length > 0 && (
-                <View className="mt-3 gap-[5px]">
-                  {part.steps.map((step, stepIndex) => (
-                    <View key={step.id} className="flex-row gap-2">
-                      <Text className="w-[22px] font-serif text-base leading-[22px] text-[hsl(18,75%,50%)]">
-                        {stepIndex + 1}
-                      </Text>
-                      <Text className="text-foreground min-w-0 flex-1 text-base font-medium leading-[22px]">
-                        {step.text}
-                      </Text>
-                    </View>
-                  ))}
-                </View>
-              )}
-            </View>
-          ))}
+                {part.steps.length > 0 && (
+                  <View className="mt-3 gap-[5px]">
+                    {part.steps.map((step, stepIndex) => (
+                      <View key={step.id} className="flex-row gap-2">
+                        <Text className="w-[22px] font-serif text-base leading-[22px] text-[hsl(18,75%,50%)]">
+                          {stepIndex + 1}
+                        </Text>
+                        <Text className="text-foreground min-w-0 flex-1 text-base font-medium leading-[22px]">
+                          {step.text}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </View>
+            );
+          })}
         </View>
       ) : (
         <View className="mt-8 items-start">
@@ -153,9 +168,9 @@ export function RecipeView({ dinner, onEdit }: Props) {
       )}
 
       {dinner.notes && (
-        <View className="mt-[26px] border-t border-[hsl(40,15%,86%)]">
-          <Text className="text-foreground mb-1.5 mt-5 font-serif text-base">
-            Tips
+        <View className="mt-[26px] border-t border-[hsl(40,15%,86%)] pt-5">
+          <Text className="text-foreground mb-1.5 font-serif text-base">
+            Notes
           </Text>
           <Text
             className="text-[15px] font-medium leading-[23px] text-[hsl(24,10%,25%)]"

--- a/apps/mobile/src/navigation/AppTabs.tsx
+++ b/apps/mobile/src/navigation/AppTabs.tsx
@@ -7,7 +7,7 @@ import { colors } from "../theme/colors";
 
 export type AppTabsParamList = {
   Plan: undefined;
-  Dinners: { openNew?: boolean; dinnerId?: number } | undefined;
+  Dinners: { openNew?: boolean } | undefined;
   Settings: undefined;
 };
 

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -1,0 +1,39 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { NavigatorScreenParams } from "@react-navigation/native";
+import { AppTabs, type AppTabsParamList } from "./AppTabs";
+import { DinnerDetailScreen } from "../screens/DinnerDetailScreen";
+import { colors } from "../theme/colors";
+
+export type RootStackParamList = {
+  Tabs: NavigatorScreenParams<AppTabsParamList> | undefined;
+  DinnerDetail: { dinnerId: number };
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export function RootNavigator() {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        contentStyle: { backgroundColor: colors.background },
+        headerStyle: { backgroundColor: colors.background },
+        headerShadowVisible: false,
+        headerTintColor: colors.foreground,
+        headerTitleStyle: {
+          fontFamily: "YoungSerif_400Regular",
+        },
+      }}
+    >
+      <Stack.Screen
+        name="Tabs"
+        component={AppTabs}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="DinnerDetail"
+        component={DinnerDetailScreen}
+        options={{ title: "Dinner" }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/apps/mobile/src/navigation/linking.ts
+++ b/apps/mobile/src/navigation/linking.ts
@@ -1,15 +1,26 @@
 import type { LinkingOptions } from "@react-navigation/native";
 import * as ExpoLinking from "expo-linking";
-import type { AppTabsParamList } from "./AppTabs";
+import type { RootStackParamList } from "./RootNavigator";
 
 const expoPrefix = ExpoLinking.createURL("/");
 
-export const linking: LinkingOptions<AppTabsParamList> = {
+export const linking: LinkingOptions<RootStackParamList> = {
   prefixes: [expoPrefix, "planeatrepeat://"],
   config: {
     screens: {
-      Plan: "plan",
-      Dinners: "dinners",
+      Tabs: {
+        screens: {
+          Plan: "plan",
+          Dinners: "dinners",
+          Settings: "settings",
+        },
+      },
+      DinnerDetail: {
+        path: "dinners/:dinnerId",
+        parse: {
+          dinnerId: Number,
+        },
+      },
     },
   },
 };

--- a/apps/mobile/src/navigation/linking.ts
+++ b/apps/mobile/src/navigation/linking.ts
@@ -7,6 +7,9 @@ const expoPrefix = ExpoLinking.createURL("/");
 export const linking: LinkingOptions<RootStackParamList> = {
   prefixes: [expoPrefix, "planeatrepeat://"],
   config: {
+    // Keep the tabs beneath DinnerDetail when opened via deep link,
+    // so back navigation returns to the app instead of exiting.
+    initialRouteName: "Tabs",
     screens: {
       Tabs: {
         screens: {

--- a/apps/mobile/src/screens/DinnerDetailScreen.tsx
+++ b/apps/mobile/src/screens/DinnerDetailScreen.tsx
@@ -1,0 +1,171 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { recipeSchema } from "@planeatrepeat/shared";
+import type { RootStackParamList } from "../navigation/RootNavigator";
+import {
+  RecipeEditor,
+  type RecipeEditorHandle,
+  type RecipeEditorValues,
+} from "../components/dinners/RecipeEditor";
+import { RecipeView } from "../components/dinners/RecipeView";
+import { Button } from "../components/ui/Button";
+import { api } from "../utils/api";
+import { colors } from "../theme/colors";
+
+type Props = NativeStackScreenProps<RootStackParamList, "DinnerDetail">;
+
+const textOrNull = (value: string | undefined) => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+};
+
+export function DinnerDetailScreen({ navigation, route }: Props) {
+  const { dinnerId } = route.params;
+  const [editing, setEditing] = useState(false);
+  const editorRef = useRef<RecipeEditorHandle>(null);
+  const utils = api.useUtils();
+
+  const dinnerQuery = api.dinner.get.useQuery({ dinnerId });
+  const editMutation = api.dinner.edit.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.dinner.get.invalidate({ dinnerId }),
+        utils.dinner.dinners.invalidate(),
+        utils.dinner.ingredientNames.invalidate(),
+      ]);
+      setEditing(false);
+    },
+    onError: (error) => {
+      Alert.alert("Could not save dinner", error.message);
+    },
+  });
+  const deleteMutation = api.dinner.delete.useMutation({
+    onSuccess: async () => {
+      setEditing(false);
+      await utils.dinner.dinners.invalidate();
+      navigation.goBack();
+    },
+    onError: (error) => {
+      Alert.alert("Could not delete dinner", error.message);
+    },
+  });
+  const isPending = editMutation.isPending || deleteMutation.isPending;
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: editing ? "Edit recipe" : "Dinner",
+      headerBackVisible: !editing,
+      gestureEnabled: !editing,
+      headerLeft: editing
+        ? () => (
+            <Pressable
+              accessibilityRole="button"
+              className="min-h-11 justify-center pr-3"
+              onPress={() => editorRef.current?.cancel()}
+            >
+              <Text className="text-muted-foreground text-sm font-semibold">
+                Cancel
+              </Text>
+            </Pressable>
+          )
+        : undefined,
+      headerRight: dinnerQuery.data?.dinner
+        ? () =>
+            editing ? (
+              <Pressable
+                accessibilityRole="button"
+                disabled={isPending}
+                className="bg-primary min-h-9 min-w-[58px] items-center justify-center rounded-lg px-3"
+                onPress={() => editorRef.current?.submit()}
+              >
+                {isPending ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={colors.primaryForeground}
+                  />
+                ) : (
+                  <Text className="text-primary-foreground text-sm font-semibold">
+                    Save
+                  </Text>
+                )}
+              </Pressable>
+            ) : (
+              <Pressable
+                accessibilityRole="button"
+                className="min-h-11 justify-center pl-3"
+                onPress={() => setEditing(true)}
+              >
+                <Text className="text-muted-foreground text-sm font-semibold">
+                  Edit
+                </Text>
+              </Pressable>
+            )
+        : undefined,
+    });
+  }, [dinnerQuery.data?.dinner, editing, isPending, navigation]);
+
+  if (dinnerQuery.isPending) {
+    return (
+      <View className="bg-background flex-1 items-center justify-center">
+        <ActivityIndicator color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (dinnerQuery.isError || !dinnerQuery.data?.dinner) {
+    return (
+      <View className="bg-background flex-1 items-center justify-center gap-4 px-6">
+        <Text className="text-foreground font-serif text-2xl">
+          Dinner not found
+        </Text>
+        <Button variant="outline" onPress={() => navigation.goBack()}>
+          Back to dinners
+        </Button>
+      </View>
+    );
+  }
+
+  const dinner = dinnerQuery.data.dinner;
+
+  const save = (values: RecipeEditorValues) => {
+    const recipe = recipeSchema.parse({
+      servings:
+        values.recipe.parts.length === 0 ? null : values.recipe.servings,
+      parts: values.recipe.parts.map((part) => ({
+        name: textOrNull(part.name),
+        ingredients: part.ingredients.map((ingredient) => ({
+          name: ingredient.name,
+          amount: ingredient.amount,
+          unit: ingredient.unit,
+          note: textOrNull(ingredient.note),
+        })),
+        steps: part.steps.map((step) => step.text),
+      })),
+    });
+
+    editMutation.mutate({
+      dinnerId: dinner.id,
+      dinnerName: values.name,
+      tagList: values.tags,
+      link: textOrNull(values.link),
+      notes: textOrNull(values.notes),
+      recipe,
+    });
+  };
+
+  if (editing) {
+    return (
+      <RecipeEditor
+        ref={editorRef}
+        dinner={dinner}
+        isPending={isPending}
+        onCancel={() => setEditing(false)}
+        onSave={save}
+        onDelete={() => deleteMutation.mutate({ dinnerId: dinner.id })}
+      />
+    );
+  }
+
+  return <RecipeView dinner={dinner} onEdit={() => setEditing(true)} />;
+}

--- a/apps/mobile/src/screens/DinnerDetailScreen.tsx
+++ b/apps/mobile/src/screens/DinnerDetailScreen.tsx
@@ -34,6 +34,9 @@ export function DinnerDetailScreen({ navigation, route }: Props) {
         utils.dinner.get.invalidate({ dinnerId }),
         utils.dinner.dinners.invalidate(),
         utils.dinner.ingredientNames.invalidate(),
+        // The Plan tab stays mounted beneath this screen, so it only
+        // refreshes through invalidation.
+        utils.plan.plannedDinners.invalidate(),
       ]);
       setEditing(false);
     },
@@ -44,7 +47,10 @@ export function DinnerDetailScreen({ navigation, route }: Props) {
   const deleteMutation = api.dinner.delete.useMutation({
     onSuccess: async () => {
       setEditing(false);
-      await utils.dinner.dinners.invalidate();
+      await Promise.all([
+        utils.dinner.dinners.invalidate(),
+        utils.plan.plannedDinners.invalidate(),
+      ]);
       navigation.goBack();
     },
     onError: (error) => {

--- a/apps/mobile/src/screens/DinnerDetailScreen.tsx
+++ b/apps/mobile/src/screens/DinnerDetailScreen.tsx
@@ -5,6 +5,7 @@ import { recipeSchema } from "@planeatrepeat/shared";
 import type { RootStackParamList } from "../navigation/RootNavigator";
 import {
   RecipeEditor,
+  parseAmount,
   type RecipeEditorHandle,
   type RecipeEditorValues,
 } from "../components/dinners/RecipeEditor";
@@ -136,7 +137,7 @@ export function DinnerDetailScreen({ navigation, route }: Props) {
         name: textOrNull(part.name),
         ingredients: part.ingredients.map((ingredient) => ({
           name: ingredient.name,
-          amount: ingredient.amount,
+          amount: parseAmount(ingredient.amount),
           unit: ingredient.unit,
           note: textOrNull(ingredient.note),
         })),

--- a/apps/mobile/src/screens/DinnerDetailScreen.tsx
+++ b/apps/mobile/src/screens/DinnerDetailScreen.tsx
@@ -1,11 +1,10 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { recipeSchema } from "@planeatrepeat/shared";
+import { parseAmount, recipeSchema } from "@planeatrepeat/shared";
 import type { RootStackParamList } from "../navigation/RootNavigator";
 import {
   RecipeEditor,
-  parseAmount,
   type RecipeEditorHandle,
   type RecipeEditorValues,
 } from "../components/dinners/RecipeEditor";

--- a/apps/mobile/src/screens/DinnersScreen.tsx
+++ b/apps/mobile/src/screens/DinnersScreen.tsx
@@ -5,6 +5,7 @@ import {
   ScrollView,
   Pressable,
   ActivityIndicator,
+  Alert,
   StyleSheet,
 } from "react-native";
 import { ChefHat } from "lucide-react-native";
@@ -50,6 +51,9 @@ export function DinnersScreen({ navigation, route }: DinnersScreenProps) {
       navigation
         .getParent<NativeStackNavigationProp<RootStackParamList>>()
         ?.navigate("DinnerDetail", { dinnerId: result.dinner.id });
+    },
+    onError: (error) => {
+      Alert.alert("Could not save dinner", error.message);
     },
   });
 

--- a/apps/mobile/src/screens/DinnersScreen.tsx
+++ b/apps/mobile/src/screens/DinnersScreen.tsx
@@ -14,12 +14,18 @@ import {
   BottomSheetScrollView,
 } from "@gorhom/bottom-sheet";
 import type { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
-import type { DinnerWithTags } from "@planeatrepeat/shared";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { AppTabsParamList } from "../navigation/AppTabs";
+import type { RootStackParamList } from "../navigation/RootNavigator";
 import { api } from "../utils/api";
 import { Screen } from "../components/Screen";
 import { Filter } from "../components/Filter";
-import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/Card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/Card";
 import { Badge } from "../components/ui/Badge";
 import { DinnerForm } from "../components/dinners/DinnerForm";
 import { colors } from "../theme/colors";
@@ -34,41 +40,20 @@ export function DinnersScreen({ navigation, route }: DinnersScreenProps) {
   const [search, setSearch] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [showTags, setShowTags] = useState(false);
-  const [selectedDinner, setSelectedDinner] = useState<DinnerWithTags | null>(
-    null,
-  );
-
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => ["85%"], []);
 
   const createDinnerMutation = api.dinner.create.useMutation({
-    onSuccess: () => {
+    onSuccess: (result) => {
       void utils.dinner.dinners.invalidate();
       bottomSheetRef.current?.dismiss();
-    },
-  });
-
-  const updateDinnerMutation = api.dinner.edit.useMutation({
-    onSuccess: () => {
-      void utils.dinner.dinners.invalidate();
-      bottomSheetRef.current?.dismiss();
-    },
-  });
-
-  const deleteDinnerMutation = api.dinner.delete.useMutation({
-    onSuccess: () => {
-      void utils.dinner.dinners.invalidate();
-      bottomSheetRef.current?.dismiss();
+      navigation
+        .getParent<NativeStackNavigationProp<RootStackParamList>>()
+        ?.navigate("DinnerDetail", { dinnerId: result.dinner.id });
     },
   });
 
   const openNewDinner = () => {
-    setSelectedDinner(null);
-    bottomSheetRef.current?.present();
-  };
-
-  const openDinner = (dinner: DinnerWithTags) => {
-    setSelectedDinner(dinner);
     bottomSheetRef.current?.present();
   };
 
@@ -77,16 +62,7 @@ export function DinnersScreen({ navigation, route }: DinnersScreenProps) {
       openNewDinner();
       navigation.setParams({ openNew: undefined });
     }
-    if (route.params?.dinnerId && dinnersQuery.data?.dinners) {
-      const dinner = dinnersQuery.data.dinners.find(
-        (d) => d.id === route.params?.dinnerId,
-      );
-      if (dinner) {
-        openDinner(dinner);
-        navigation.setParams({ dinnerId: undefined });
-      }
-    }
-  }, [route.params, dinnersQuery.data, navigation]);
+  }, [route.params?.openNew, navigation]);
 
   const dinners = dinnersQuery.data?.dinners
     .filter(
@@ -109,9 +85,7 @@ export function DinnersScreen({ navigation, route }: DinnersScreenProps) {
     <Screen edges={["top", "left", "right"]}>
       <View className="flex-1 gap-4">
         <View className="gap-2">
-          <Text className="font-serif text-3xl text-foreground">
-            Dinners
-          </Text>
+          <Text className="text-foreground font-serif text-3xl">Dinners</Text>
           <Filter
             search={search}
             setSearch={setSearch}
@@ -141,7 +115,7 @@ export function DinnersScreen({ navigation, route }: DinnersScreenProps) {
                 <Card className="min-h-[100px] border-dashed bg-transparent">
                   <CardContent className="flex-1 items-center justify-center gap-2 p-4">
                     <ChefHat size={24} color={colors.mutedForeground} />
-                    <Text className="text-sm font-medium text-muted-foreground">
+                    <Text className="text-muted-foreground text-sm font-medium">
                       Add new dinner
                     </Text>
                   </CardContent>
@@ -149,8 +123,17 @@ export function DinnersScreen({ navigation, route }: DinnersScreenProps) {
               </Pressable>
 
               {dinners?.map((dinner) => (
-                <Pressable key={dinner.id} onPress={() => openDinner(dinner)}>
-                  <Card className="min-h-[100px] bg-card">
+                <Pressable
+                  key={dinner.id}
+                  onPress={() =>
+                    navigation
+                      .getParent<
+                        NativeStackNavigationProp<RootStackParamList>
+                      >()
+                      ?.navigate("DinnerDetail", { dinnerId: dinner.id })
+                  }
+                >
+                  <Card className="bg-card min-h-[100px]">
                     <CardHeader className="p-4 pb-2">
                       <CardTitle
                         className="text-base leading-tight"
@@ -195,43 +178,20 @@ export function DinnersScreen({ navigation, route }: DinnersScreenProps) {
           contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24 }}
         >
           <View className="gap-4">
-            <Text className="font-serif text-2xl text-foreground">
-              {selectedDinner ? "Edit dinner" : "New dinner"}
+            <Text className="text-foreground font-serif text-2xl">
+              New dinner
             </Text>
             <DinnerForm
-              existingDinner={selectedDinner}
               onCancel={() => bottomSheetRef.current?.dismiss()}
-              isPending={
-                createDinnerMutation.isPending ||
-                updateDinnerMutation.isPending ||
-                deleteDinnerMutation.isPending
-              }
+              isPending={createDinnerMutation.isPending}
               onSubmit={(values) => {
-                if (selectedDinner) {
-                  updateDinnerMutation.mutate({
-                    dinnerId: selectedDinner.id,
-                    dinnerName: values.name,
-                    tagList: values.tags,
-                    link: values.link,
-                    notes: values.notes,
-                  });
-                } else {
-                  createDinnerMutation.mutate({
-                    dinnerName: values.name,
-                    tagList: values.tags,
-                    link: values.link,
-                    notes: values.notes,
-                  });
-                }
+                createDinnerMutation.mutate({
+                  dinnerName: values.name,
+                  tagList: values.tags,
+                  link: values.link,
+                  notes: values.notes,
+                });
               }}
-              onDelete={
-                selectedDinner
-                  ? () =>
-                      deleteDinnerMutation.mutate({
-                        dinnerId: selectedDinner.id,
-                      })
-                  : undefined
-              }
             />
           </View>
         </BottomSheetScrollView>

--- a/apps/mobile/src/screens/PlanScreen.tsx
+++ b/apps/mobile/src/screens/PlanScreen.tsx
@@ -24,8 +24,10 @@ import {
   BottomSheetScrollView,
 } from "@gorhom/bottom-sheet";
 import type { BottomTabScreenProps } from "@react-navigation/bottom-tabs";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { DinnerWithTags } from "@planeatrepeat/shared";
 import type { AppTabsParamList } from "../navigation/AppTabs";
+import type { RootStackParamList } from "../navigation/RootNavigator";
 import { api } from "../utils/api";
 import { cn } from "../utils/cn";
 import { Screen } from "../components/Screen";
@@ -125,7 +127,11 @@ export function PlanScreen({
 
   const renderBackdrop = useCallback(
     (props: any) => (
-      <BottomSheetBackdrop appearsOnIndex={0} disappearsOnIndex={-1} {...props} />
+      <BottomSheetBackdrop
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        {...props}
+      />
     ),
     [],
   );
@@ -149,7 +155,7 @@ export function PlanScreen({
     <Screen edges={["top", "left", "right"]} contentClassName="relative">
       <View className="flex-1 gap-4">
         <View className="gap-2">
-          <Text className="font-serif text-3xl text-foreground">
+          <Text className="text-foreground font-serif text-3xl">
             Weekly Plan
           </Text>
         </View>
@@ -170,10 +176,9 @@ export function PlanScreen({
               contentContainerStyle={{ paddingBottom: 156, gap: 8 }}
             >
               {week.map((day) => {
-                const plannedDinner =
-                  plannedDinnersQuery.data?.plans.find((p) =>
-                    isSameDay(p.date, day),
-                  )?.dinner;
+                const plannedDinner = plannedDinnersQuery.data?.plans.find(
+                  (p) => isSameDay(p.date, day),
+                )?.dinner;
                 return (
                   <DayCard
                     key={day.toString()}
@@ -189,7 +194,7 @@ export function PlanScreen({
       </View>
 
       <View className="absolute bottom-4 left-0 right-0 items-center px-4">
-        <View className="rounded-lg border border-border bg-background/95 p-2 shadow-lg">
+        <View className="border-border bg-background/95 rounded-lg border p-2 shadow-lg">
           <WeekSelect
             setWeekOffSet={setWeekOffSet}
             startOfDisplayedWeek={startOfDisplayedWeek}
@@ -211,10 +216,10 @@ export function PlanScreen({
           >
             <View className="gap-4">
               <View className="gap-1">
-                <Text className="text-sm text-muted-foreground">
+                <Text className="text-muted-foreground text-sm">
                   {selectedDate ? format(selectedDate, "EEEE, LLLL do, y") : ""}
                 </Text>
-                <Text className="font-serif text-2xl text-foreground">
+                <Text className="text-foreground font-serif text-2xl">
                   {selectedDinner?.name ?? "Nothing planned yet"}
                 </Text>
               </View>
@@ -238,14 +243,14 @@ export function PlanScreen({
                     className={cn(
                       "justify-start",
                       selectedDinner?.id === dinner.id &&
-                      "bg-accent/50 text-accent-foreground",
+                        "bg-accent/50 text-accent-foreground",
                     )}
                   >
                     <Text
                       className={cn(
                         "text-foreground",
                         selectedDinner?.id === dinner.id &&
-                        "text-accent-foreground",
+                          "text-accent-foreground",
                       )}
                     >
                       {dinner.name}
@@ -291,10 +296,10 @@ export function PlanScreen({
           >
             <View className="gap-4">
               <View className="gap-1">
-                <Text className="text-sm text-muted-foreground">
+                <Text className="text-muted-foreground text-sm">
                   {selectedDate ? format(selectedDate, "EEEE, LLLL do, y") : ""}
                 </Text>
-                <Text className="font-serif text-2xl text-foreground">
+                <Text className="text-foreground font-serif text-2xl">
                   {selectedDinner?.name ?? ""}
                 </Text>
               </View>
@@ -323,7 +328,7 @@ export function PlanScreen({
                 {!!selectedDinner?.notes && (
                   <View className="gap-1">
                     {selectedDinner.notes.split("\n").map((line) => (
-                      <Text key={line} className="text-sm text-foreground">
+                      <Text key={line} className="text-foreground text-sm">
                         {line}
                       </Text>
                     ))}
@@ -353,12 +358,16 @@ export function PlanScreen({
                       variant="outline"
                       onPress={() => {
                         bottomSheetRef.current?.dismiss();
-                        navigation.navigate("Dinners", {
-                          dinnerId: selectedDinner.id,
-                        });
+                        navigation
+                          .getParent<
+                            NativeStackNavigationProp<RootStackParamList>
+                          >()
+                          ?.navigate("DinnerDetail", {
+                            dinnerId: selectedDinner.id,
+                          });
                       }}
                     >
-                      Edit dinner
+                      View recipe
                     </Button>
                   )}
                 </View>
@@ -393,7 +402,8 @@ function DayCard({ date, plannedDinner, onPress }: DayCardProps) {
     <Pressable onPress={onPress}>
       <View
         className={cn(
-          isDateToday && "rounded-lg border-2 border-primary bg-background p-[2px]",
+          isDateToday &&
+            "border-primary bg-background rounded-lg border-2 p-[2px]",
         )}
       >
         <Card
@@ -406,8 +416,8 @@ function DayCard({ date, plannedDinner, onPress }: DayCardProps) {
           <CardHeader className="p-3 pb-1">
             <Text
               className={cn(
-                "text-sm font-medium text-muted-foreground",
-                isDateToday && "font-bold text-primary",
+                "text-muted-foreground text-sm font-medium",
+                isDateToday && "text-primary font-bold",
               )}
             >
               {format(date, "EEE do")}
@@ -416,7 +426,7 @@ function DayCard({ date, plannedDinner, onPress }: DayCardProps) {
           <CardContent className="p-3 pt-1">
             {plannedDinner ? (
               <Text
-                className="font-serif text-base text-foreground"
+                className="text-foreground font-serif text-base"
                 numberOfLines={2}
                 ellipsizeMode="tail"
               >

--- a/apps/web/src/components/ui/FancyCombobox.tsx
+++ b/apps/web/src/components/ui/FancyCombobox.tsx
@@ -111,6 +111,7 @@ export const FancyCombobox = ({
               <Badge key={option.value} variant="secondary">
                 {option.label}
                 <button
+                  type="button"
                   className="ml-1 rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {

--- a/apps/web/src/pages/dinners/[dinnerId].tsx
+++ b/apps/web/src/pages/dinners/[dinnerId].tsx
@@ -1,15 +1,15 @@
 import Head from "next/head";
-import { DinnersView } from "../../views/Dinners/DinnersView";
+import { DinnerDetail } from "../../views/Dinners/DinnerDetail";
 
-export default function Home() {
+export default function DinnerDetailPage() {
   return (
     <>
       <Head>
-        <title>PlanEatRepeat</title>
-        <meta name="description" content="The easiest way to plan dinners" />
+        <title>Dinner · PlanEatRepeat</title>
+        <meta name="description" content="View and edit a dinner recipe" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <DinnersView />
+      <DinnerDetail />
     </>
   );
 }

--- a/apps/web/src/views/Dinners/DeleteDinnerButton.tsx
+++ b/apps/web/src/views/Dinners/DeleteDinnerButton.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { format } from "date-fns";
+import { Trash2 } from "lucide-react";
+import { api } from "../../utils/api";
+import { Button } from "../../components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../../components/ui/dialog";
+
+type Props = {
+  dinnerId: number;
+  isPending: boolean;
+  onDelete: () => void;
+};
+
+export const DeleteDinnerButton = ({
+  dinnerId,
+  isPending,
+  onDelete,
+}: Props) => {
+  const [open, setOpen] = useState(false);
+  const plansQuery = api.plan.plansForDinner.useQuery(
+    { dinnerId },
+    { enabled: open },
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className="hover:bg-destructive/5 w-full border-[hsl(0_50%_85%)] text-[hsl(0_60%_48%)] hover:text-[hsl(0_60%_42%)]"
+        >
+          <Trash2 />
+          Delete dinner
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete dinner</DialogTitle>
+          <DialogDescription>
+            Are you sure? This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        {plansQuery.isSuccess && plansQuery.data.plans.length > 0 && (
+          <div className="space-y-2 text-sm">
+            <p>The plans on these dates will also be deleted:</p>
+            <ul className="max-h-[200px] space-y-1 overflow-y-auto rounded-md border p-3">
+              {plansQuery.data.plans.map((plan) => (
+                <li key={plan.id}>{format(plan.date, "LLLL do, y")}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={isPending || plansQuery.isPending}
+            onClick={onDelete}
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/src/views/Dinners/DinnerDetail.tsx
+++ b/apps/web/src/views/Dinners/DinnerDetail.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { ArrowLeft, UtensilsCrossed } from "lucide-react";
+import { recipeSchema } from "@planeatrepeat/shared";
+import { usePostHog } from "posthog-js/react";
+import { api } from "../../utils/api";
+import { toast } from "../../components/ui/use-toast";
+import { Button } from "../../components/ui/button";
+import { RecipeEditor, type RecipeEditorValues } from "./RecipeEditor";
+import { RecipeView } from "./RecipeView";
+
+const textOrNull = (value: string | undefined) => {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return trimmed;
+};
+
+export const DinnerDetail = () => {
+  const router = useRouter();
+  const posthog = usePostHog();
+  const utils = api.useUtils();
+  const [editing, setEditing] = useState(false);
+  const rawDinnerId = router.query.dinnerId;
+  const dinnerId =
+    typeof rawDinnerId === "string" ? Number(rawDinnerId) : Number.NaN;
+  const validDinnerId = Number.isInteger(dinnerId);
+
+  const dinnerQuery = api.dinner.get.useQuery(
+    { dinnerId },
+    { enabled: router.isReady && validDinnerId },
+  );
+
+  const editMutation = api.dinner.edit.useMutation({
+    onSuccess: async (result) => {
+      toast({ title: `${result.dinner.name} updated` });
+      await Promise.all([
+        utils.dinner.get.invalidate({ dinnerId }),
+        utils.dinner.dinners.invalidate(),
+        utils.dinner.ingredientNames.invalidate(),
+      ]);
+      setEditing(false);
+    },
+    onError: (error) => {
+      toast({
+        variant: "destructive",
+        title: "Could not save dinner",
+        description: error.message,
+      });
+    },
+  });
+
+  const deleteMutation = api.dinner.delete.useMutation({
+    onSuccess: async (result) => {
+      toast({ title: `${result.dinner.name} deleted` });
+      await utils.dinner.dinners.invalidate();
+      void router.push("/dinners");
+    },
+    onError: (error) => {
+      toast({
+        variant: "destructive",
+        title: "Could not delete dinner",
+        description: error.message,
+      });
+    },
+  });
+
+  if (!router.isReady || dinnerQuery.isPending) {
+    return (
+      <div className="flex h-[50vh] items-center justify-center">
+        <UtensilsCrossed className="text-primary animate-spin" />
+      </div>
+    );
+  }
+
+  if (!validDinnerId || dinnerQuery.isError || !dinnerQuery.data?.dinner) {
+    return (
+      <div className="mx-auto max-w-[640px] space-y-4 py-12 text-center">
+        <h1 className="font-serif text-2xl">Dinner not found</h1>
+        <Button asChild variant="outline">
+          <Link href="/dinners">
+            <ArrowLeft />
+            Back to dinners
+          </Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const dinner = dinnerQuery.data.dinner;
+
+  const save = (values: RecipeEditorValues) => {
+    const recipe = recipeSchema.parse({
+      servings:
+        values.recipe.parts.length === 0 ? null : values.recipe.servings,
+      parts: values.recipe.parts.map((part) => ({
+        name: textOrNull(part.name),
+        ingredients: part.ingredients.map((ingredient) => ({
+          name: ingredient.name,
+          amount: ingredient.amount,
+          unit: ingredient.unit,
+          note: textOrNull(ingredient.note),
+        })),
+        steps: part.steps.map((step) => step.text),
+      })),
+    });
+
+    posthog.capture("update dinner", { dinnerName: values.name });
+    editMutation.mutate({
+      dinnerId: dinner.id,
+      dinnerName: values.name,
+      tagList: values.tags,
+      link: textOrNull(values.link),
+      notes: textOrNull(values.notes),
+      recipe,
+    });
+  };
+
+  if (editing) {
+    return (
+      <RecipeEditor
+        dinner={dinner}
+        isPending={editMutation.isPending || deleteMutation.isPending}
+        onCancel={() => setEditing(false)}
+        onSave={save}
+        onDelete={() => {
+          posthog.capture("delete dinner", { dinnerName: dinner.name });
+          deleteMutation.mutate({ dinnerId: dinner.id });
+        }}
+      />
+    );
+  }
+
+  return <RecipeView dinner={dinner} onEdit={() => setEditing(true)} />;
+};

--- a/apps/web/src/views/Dinners/DinnerDetail.tsx
+++ b/apps/web/src/views/Dinners/DinnerDetail.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { ArrowLeft, UtensilsCrossed } from "lucide-react";
-import { recipeSchema } from "@planeatrepeat/shared";
+import { parseAmount, recipeSchema } from "@planeatrepeat/shared";
 import { usePostHog } from "posthog-js/react";
 import { api } from "../../utils/api";
 import { toast } from "../../components/ui/use-toast";
@@ -97,7 +97,7 @@ export const DinnerDetail = () => {
         name: textOrNull(part.name),
         ingredients: part.ingredients.map((ingredient) => ({
           name: ingredient.name,
-          amount: ingredient.amount,
+          amount: parseAmount(ingredient.amount),
           unit: ingredient.unit,
           note: textOrNull(ingredient.note),
         })),

--- a/apps/web/src/views/Dinners/DinnerForm.tsx
+++ b/apps/web/src/views/Dinners/DinnerForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type z } from "zod";
-import { dinnerFormSchema, type DinnerWithTags } from "../../utils/types";
+import { dinnerFormSchema } from "../../utils/types";
 import { useForm, type UseFormReturn } from "react-hook-form";
 import {
   Form,
@@ -16,42 +16,22 @@ import { Textarea } from "../../components/ui/textarea";
 import { Label } from "../../components/ui/label";
 import { FancyCombobox } from "../../components/ui/FancyCombobox";
 import { api } from "../../utils/api";
-import { Trash2 } from "lucide-react";
-import {
-  Dialog,
-  DialogFooter,
-  DialogDescription,
-  DialogTitle,
-  DialogHeader,
-  DialogTrigger,
-  DialogContent,
-} from "../../components/ui/dialog";
-import { useState } from "react";
-import { format } from "date-fns";
 
 type Props = {
   onSubmit: (values: z.infer<typeof dinnerFormSchema>) => void;
-  onDelete?: (values: z.infer<typeof dinnerFormSchema>) => void;
-  existingDinner?: DinnerWithTags;
   closeDialog: () => void;
   isPending: boolean;
 };
 
-export const DinnerForm = ({
-  onSubmit,
-  onDelete,
-  existingDinner,
-  closeDialog,
-  isPending,
-}: Props) => {
+export const DinnerForm = ({ onSubmit, closeDialog, isPending }: Props) => {
   const form = useForm<z.infer<typeof dinnerFormSchema>>({
     resolver: zodResolver(dinnerFormSchema),
     defaultValues: {
-      name: existingDinner?.name ?? "",
-      tags: existingDinner?.tags.map((tag) => tag.value) ?? [],
+      name: "",
+      tags: [],
       newTag: "",
-      link: existingDinner?.link ?? "",
-      notes: existingDinner?.notes ?? "",
+      link: "",
+      notes: "",
     },
   });
 
@@ -106,23 +86,13 @@ export const DinnerForm = ({
             </FormItem>
           )}
         />
-        <div className="flex justify-between">
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={closeDialog}>
+            Cancel
+          </Button>
           <Button type="submit" disabled={isPending}>
             Save
           </Button>
-          <div className="flex gap-2">
-            {onDelete && existingDinner && (
-              <Delete
-                onDelete={onDelete}
-                isPending={isPending}
-                form={form}
-                dinner={existingDinner}
-              />
-            )}
-            <Button type="button" variant={"outline"} onClick={closeDialog}>
-              {"Cancel"}
-            </Button>
-          </div>
         </div>
       </form>
     </Form>
@@ -176,68 +146,5 @@ const TagsCombobox = ({ form }: TagsComboboxProps) => {
       removeLast={removeLast}
       createNew={createNew}
     />
-  );
-};
-type DeleteProps = {
-  onDelete: (values: z.infer<typeof dinnerFormSchema>) => void;
-  isPending: boolean;
-  form: UseFormReturn<z.infer<typeof dinnerFormSchema>>;
-  dinner: DinnerWithTags;
-};
-
-const Delete = ({ onDelete, isPending, form, dinner }: DeleteProps) => {
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const plansQuery = api.plan.plansForDinner.useQuery({
-    dinnerId: dinner.id,
-  });
-
-  return (
-    <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-      <DialogTrigger asChild>
-        <Button type="button" variant={"destructive"}>
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Delete dinner</DialogTitle>
-          <DialogDescription>
-            Are you sure you want to delete this dinner? This action cannot be
-            undone.
-          </DialogDescription>
-        </DialogHeader>
-        {plansQuery.isSuccess && (
-          <div className="space-y-2">
-            <p>
-              If you delete this dinner, the plan for the following dates will
-              also be deleted:
-            </p>
-            <div className="max-h-[200px] overflow-y-auto rounded border p-2">
-              <ul className="space-y-1">
-                {plansQuery.data.plans.map((plan) => (
-                  <li key={plan.id}>{format(plan.date, "LLLL do, y")}</li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        )}
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => setDialogOpen(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            disabled={isPending || plansQuery.isPending}
-            onClick={async () => {
-              await form.handleSubmit(onDelete)();
-              setDialogOpen(false);
-            }}
-          >
-            Delete
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 };

--- a/apps/web/src/views/Dinners/DinnerList.tsx
+++ b/apps/web/src/views/Dinners/DinnerList.tsx
@@ -1,12 +1,7 @@
+import Link from "next/link";
 import { cn } from "../../lib/utils";
-import { type dinnerFormSchema, type DinnerWithTags } from "../../utils/types";
-import { DinnerForm } from "./DinnerForm";
-import { type z } from "zod";
-import { api } from "../../utils/api";
-import { toast } from "../../components/ui/use-toast";
-import { usePostHog } from "posthog-js/react";
+import { type DinnerWithTags } from "../../utils/types";
 import { NewDinner } from "./NewDinner";
-import { useRouter } from "next/router";
 import { Badge } from "../../components/ui/badge";
 import {
   Card,
@@ -14,13 +9,6 @@ import {
   CardHeader,
   CardTitle,
 } from "../../components/ui/card";
-import {
-  ResponsiveModal,
-  ResponsiveModalContent,
-  ResponsiveModalHeader,
-  ResponsiveModalTitle,
-  ResponsiveModalTrigger,
-} from "../../components/ResponsiveModal";
 
 type Props = {
   dinners: DinnerWithTags[];
@@ -31,137 +19,37 @@ export const DinnerList = ({ dinners, selectedTags }: Props) => {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       <NewDinner />
-      {dinners.map((d) => (
-        <DinnerListItem key={d.id} dinner={d} selectedTags={selectedTags} />
-      ))}
-    </div>
-  );
-};
-
-type DinnerListItemProps = {
-  dinner: DinnerWithTags;
-  selectedTags: string[];
-};
-
-const DinnerListItem = ({ dinner, selectedTags }: DinnerListItemProps) => {
-  const router = useRouter();
-  const dialogOpen = Number(router.query.dinnerId) === dinner.id;
-  const setDialogOpen = (open: boolean) => {
-    void router.push(open ? `/dinners/${dinner.id}` : "/dinners");
-  };
-
-  const updateDinnerMutation = api.dinner.edit.useMutation({
-    onSuccess: (result) => {
-      toast({
-        title: `${result.dinner.name} updated`,
-      });
-      setDialogOpen(false);
-    },
-    onError: (error) => {
-      toast({
-        variant: "destructive",
-        title: "Something went wrong",
-        description: error.message,
-      });
-    },
-  });
-
-  const deleteDinnerMutation = api.dinner.delete.useMutation({
-    onSuccess: (result) => {
-      toast({
-        title: `${result.dinner.name} deleted`,
-      });
-      setDialogOpen(false);
-    },
-    onError: (error) => {
-      toast({
-        variant: "destructive",
-        title: "Something went wrong",
-        description: error.message,
-      });
-    },
-  });
-
-  const utils = api.useUtils();
-  const posthog = usePostHog();
-
-  function updateDinner(values: z.infer<typeof dinnerFormSchema>) {
-    posthog.capture("update dinner", { dinnerName: values.name });
-
-    updateDinnerMutation.mutate(
-      {
-        dinnerName: values.name,
-        dinnerId: dinner.id,
-        tagList: values.tags,
-        link: values.link,
-        notes: values.notes,
-      },
-      {
-        onSettled: () => {
-          void utils.dinner.dinners.invalidate();
-        },
-      },
-    );
-  }
-
-  function deleteDinner(values: z.infer<typeof dinnerFormSchema>) {
-    posthog.capture("delete dinner", { dinnerName: values.name });
-
-    deleteDinnerMutation.mutate(
-      {
-        dinnerId: dinner.id,
-      },
-      {
-        onSettled: () => {
-          void utils.dinner.dinners.invalidate();
-        },
-      },
-    );
-  }
-
-  return (
-    <ResponsiveModal open={dialogOpen} onOpenChange={setDialogOpen}>
-      <ResponsiveModalTrigger asChild>
-        <Card className="flex h-full min-h-[100px] cursor-pointer flex-col justify-between transition-colors hover:bg-accent/50">
-          <CardHeader className="p-4 pb-2">
-            <CardTitle className="line-clamp-2 font-serif text-base font-medium leading-tight sm:text-lg">
-              {dinner.name}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-4 pt-2">
-            <div className="flex flex-wrap gap-2">
-              {dinner.tags.map((tag) => {
-                return (
+      {dinners.map((dinner) => (
+        <Link
+          key={dinner.id}
+          href={`/dinners/${dinner.id}`}
+          className="block h-full"
+        >
+          <Card className="hover:bg-accent/50 flex h-full min-h-[100px] cursor-pointer flex-col justify-between transition-colors">
+            <CardHeader className="p-4 pb-2">
+              <CardTitle className="line-clamp-2 font-serif text-base font-medium leading-tight sm:text-lg">
+                {dinner.name}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-4 pt-2">
+              <div className="flex flex-wrap gap-2">
+                {dinner.tags.map((tag) => (
                   <Badge
                     key={tag.value}
                     variant="secondary"
                     className={cn(
                       selectedTags.includes(tag.value) &&
-                      "border border-primary bg-primary/10",
+                        "border-primary bg-primary/10 border",
                     )}
                   >
                     {tag.value}
                   </Badge>
-                );
-              })}
-            </div>
-          </CardContent>
-        </Card>
-      </ResponsiveModalTrigger>
-      <ResponsiveModalContent>
-        <ResponsiveModalHeader>
-          <ResponsiveModalTitle>{dinner.name}</ResponsiveModalTitle>
-        </ResponsiveModalHeader>
-        <DinnerForm
-          existingDinner={dinner}
-          closeDialog={() => setDialogOpen(false)}
-          onSubmit={updateDinner}
-          onDelete={deleteDinner}
-          isPending={
-            updateDinnerMutation.isPending || deleteDinnerMutation.isPending
-          }
-        />
-      </ResponsiveModalContent>
-    </ResponsiveModal>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      ))}
+    </div>
   );
 };

--- a/apps/web/src/views/Dinners/NewDinner.tsx
+++ b/apps/web/src/views/Dinners/NewDinner.tsx
@@ -29,7 +29,7 @@ export const NewDinner = () => {
       toast({
         title: `${result.dinner.name} created`,
       });
-      setDialogOpen(false);
+      void router.push(`/dinners/${result.dinner.id}`);
     },
     onSettled: () => {
       void utils.dinner.dinners.invalidate();

--- a/apps/web/src/views/Dinners/NewDinner.tsx
+++ b/apps/web/src/views/Dinners/NewDinner.tsx
@@ -31,6 +31,13 @@ export const NewDinner = () => {
       });
       void router.push(`/dinners/${result.dinner.id}`);
     },
+    onError: (error) => {
+      toast({
+        variant: "destructive",
+        title: "Could not create dinner",
+        description: error.message,
+      });
+    },
     onSettled: () => {
       void utils.dinner.dinners.invalidate();
     },

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -419,9 +419,6 @@ const PartEditor = ({
       <div className="mt-1">
         {ingredients.fields.map((ingredient, ingredientIndex) => {
           const isExpanded = expandedId === ingredient.id;
-          const note = form.watch(
-            `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.note`,
-          );
           const ingredientError =
             form.formState.errors.recipe?.parts?.[partIndex]?.ingredients?.[
               ingredientIndex
@@ -446,6 +443,7 @@ const PartEditor = ({
                   inputMode="decimal"
                   aria-label={`Ingredient ${ingredientIndex + 1} amount`}
                   className="focus:border-primary focus:ring-primary/15 h-9 min-w-0 rounded-md border bg-white px-1 text-center font-bold outline-none focus:ring-[3px]"
+                  onFocus={() => open(ingredient.id)}
                 />
                 <Controller
                   control={form.control}
@@ -455,6 +453,7 @@ const PartEditor = ({
                       ref={field.ref}
                       value={field.value ?? ""}
                       onBlur={field.onBlur}
+                      onFocus={() => open(ingredient.id)}
                       onChange={(event) =>
                         field.onChange(event.target.value || null)
                       }
@@ -476,9 +475,10 @@ const PartEditor = ({
                       `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`,
                     )}
                     list="recipe-ingredient-names"
-                    className="h-9 min-w-0 bg-white px-2"
+                    className="h-9 min-w-0 bg-white px-2 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-list-button]:hidden"
                     placeholder="Ingredient"
                     aria-label={`Ingredient ${ingredientIndex + 1} name`}
+                    onFocus={() => open(ingredient.id)}
                   />
                   <FieldError message={ingredientError?.name?.message} />
                 </div>
@@ -489,11 +489,12 @@ const PartEditor = ({
                       ? "Hide ingredient controls"
                       : "Show ingredient controls"
                   }
-                  className={cn(
-                    "text-muted-foreground flex h-9 items-center justify-center rounded-md",
-                    note && "text-primary",
-                  )}
-                  onClick={() => toggle(ingredient.id)}
+                  aria-expanded={isExpanded}
+                  className="text-muted-foreground flex h-9 items-center justify-center rounded-md [&_svg]:pointer-events-none"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    toggle(ingredient.id);
+                  }}
                 >
                   {isExpanded ? <ChevronDown /> : <ChevronRight />}
                 </button>
@@ -590,8 +591,12 @@ const PartEditor = ({
                     aria-label={
                       isExpanded ? "Hide step controls" : "Show step controls"
                     }
-                    className="text-muted-foreground flex h-10 items-center justify-center rounded-md"
-                    onClick={() => toggle(step.id)}
+                    aria-expanded={isExpanded}
+                    className="text-muted-foreground flex h-10 items-center justify-center rounded-md [&_svg]:pointer-events-none"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      toggle(step.id);
+                    }}
                   >
                     {isExpanded ? <ChevronDown /> : <ChevronRight />}
                   </button>

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -349,12 +349,29 @@ const PartEditor = ({
   const open = (id: string) => setExpandedId(id);
   const toggle = (id: string) =>
     setExpandedId((current) => (current === id ? null : id));
-  const collapseOnBlur =
-    (id: string) => (event: React.FocusEvent<HTMLDivElement>) => {
-      if (!event.currentTarget.contains(event.relatedTarget)) {
-        setExpandedId((current) => (current === id ? null : current));
+
+  // Collapse on click-outside via a document `click` listener, never on
+  // blur or pointerdown: collapsing shifts the layout, and doing that
+  // between mousedown and mouseup moves whatever the user is pressing
+  // (e.g. the add buttons below the row) out from under the cursor, so the
+  // click never lands. `click` fires after the pressed element's own
+  // handler has run.
+  useEffect(() => {
+    if (expandedId === null) return;
+
+    const collapse = (event: MouseEvent) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const rowId = target
+        ?.closest("[data-row-id]")
+        ?.getAttribute("data-row-id");
+      if (rowId !== expandedId) {
+        setExpandedId((current) => (current === expandedId ? null : current));
       }
     };
+
+    document.addEventListener("click", collapse);
+    return () => document.removeEventListener("click", collapse);
+  }, [expandedId]);
 
   return (
     <section
@@ -413,7 +430,7 @@ const PartEditor = ({
           return (
             <div
               key={ingredient.id}
-              onBlur={collapseOnBlur(ingredient.id)}
+              data-row-id={ingredient.id}
               className={cn(
                 "border-b border-[hsl(40_15%_92%)] px-1 py-1.5",
                 isExpanded &&
@@ -543,7 +560,7 @@ const PartEditor = ({
             return (
               <div
                 key={step.id}
-                onBlur={collapseOnBlur(step.id)}
+                data-row-id={step.id}
                 className={cn(
                   "border-b border-[hsl(40_15%_92%)] px-1 py-1.5",
                   isExpanded &&

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -20,6 +20,7 @@ import {
 import {
   UNITS,
   type DinnerWithRecipe,
+  amountInputSchema,
   recipeIngredientSchema,
 } from "@planeatrepeat/shared";
 import { api } from "../../utils/api";
@@ -31,9 +32,11 @@ import { Form } from "../../components/ui/form";
 import { FancyCombobox } from "../../components/ui/FancyCombobox";
 import { DeleteDinnerButton } from "./DeleteDinnerButton";
 
+// Amounts are edited as text so comma decimals like "1,5" can be typed;
+// parseAmount converts back to a number on save.
 const editorIngredientSchema = recipeIngredientSchema.extend({
   name: z.string().trim().min(1, "Name required"),
-  amount: z.number().positive("Amount must be more than 0").nullable(),
+  amount: amountInputSchema,
   note: z.string(),
 });
 
@@ -96,7 +99,7 @@ export const RecipeEditor = ({
           name: part.name ?? "",
           ingredients: part.ingredients.map((ingredient) => ({
             name: ingredient.name,
-            amount: ingredient.amount,
+            amount: ingredient.amount === null ? "" : String(ingredient.amount),
             unit: UNITS.find((unit) => unit === ingredient.unit) ?? null,
             note: ingredient.note ?? "",
           })),
@@ -153,75 +156,81 @@ export const RecipeEditor = ({
         </div>
 
         <div className="space-y-5">
-          <div>
+          <div className="space-y-1.5">
+            <FieldLabel htmlFor="dinner-name">Name</FieldLabel>
             <Input
               {...form.register("name")}
-              aria-label="Dinner name"
+              id="dinner-name"
               className="h-12 bg-white text-lg font-semibold"
-              placeholder="Dinner name"
             />
             <FieldError message={form.formState.errors.name?.message} />
           </div>
 
-          <div className="grid grid-cols-[116px_1fr] gap-2">
-            <div
-              className="grid h-10 grid-cols-[32px_1fr_32px] overflow-hidden rounded-md border bg-white"
-              aria-label="Servings"
-            >
-              <button
-                type="button"
-                aria-label="Decrease servings"
-                className="text-muted-foreground hover:bg-accent flex items-center justify-center border-r"
-                onClick={() =>
-                  form.setValue(
-                    "recipe.servings",
-                    Math.max(1, (servings ?? 2) - 1),
-                    { shouldDirty: true },
-                  )
-                }
-              >
-                <Minus className="h-3.5 w-3.5" />
-              </button>
-              <input
-                {...form.register("recipe.servings", {
-                  setValueAs: (value) => (value === "" ? null : Number(value)),
-                })}
-                className="min-w-0 bg-transparent text-center font-bold outline-none"
-                type="number"
-                min={1}
-                inputMode="numeric"
-                placeholder="–"
-                aria-label="Number of servings"
-              />
-              <button
-                type="button"
-                aria-label="Increase servings"
-                className="text-muted-foreground hover:bg-accent flex items-center justify-center border-l"
-                onClick={() =>
-                  form.setValue("recipe.servings", (servings ?? 0) + 1, {
-                    shouldDirty: true,
-                  })
-                }
-              >
-                <Plus className="h-3.5 w-3.5" />
-              </button>
+          <div>
+            <div className="grid grid-cols-[116px_1fr] gap-2">
+              <div className="space-y-1.5">
+                <FieldLabel>Servings</FieldLabel>
+                <div className="grid h-10 grid-cols-[32px_1fr_32px] overflow-hidden rounded-md border bg-white">
+                  <button
+                    type="button"
+                    aria-label="Decrease servings"
+                    className="text-muted-foreground hover:bg-accent flex items-center justify-center border-r"
+                    onClick={() =>
+                      form.setValue(
+                        "recipe.servings",
+                        Math.max(1, (servings ?? 2) - 1),
+                        { shouldDirty: true },
+                      )
+                    }
+                  >
+                    <Minus className="h-3.5 w-3.5" />
+                  </button>
+                  <input
+                    {...form.register("recipe.servings", {
+                      setValueAs: (value) =>
+                        value === "" ? null : Number(value),
+                    })}
+                    className="min-w-0 bg-transparent text-center font-bold outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                    type="number"
+                    min={1}
+                    inputMode="numeric"
+                    placeholder="–"
+                    aria-label="Number of servings"
+                  />
+                  <button
+                    type="button"
+                    aria-label="Increase servings"
+                    className="text-muted-foreground hover:bg-accent flex items-center justify-center border-l"
+                    onClick={() =>
+                      form.setValue("recipe.servings", (servings ?? 0) + 1, {
+                        shouldDirty: true,
+                      })
+                    }
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel htmlFor="recipe-link">Recipe link</FieldLabel>
+                <Input
+                  {...form.register("link")}
+                  id="recipe-link"
+                  type="url"
+                  className="bg-white"
+                />
+              </div>
             </div>
-            <Input
-              {...form.register("link")}
-              type="url"
-              className="bg-white"
-              placeholder="Recipe link"
-              aria-label="Recipe link"
+            <FieldError
+              message={
+                form.formState.errors.link?.message ??
+                form.formState.errors.recipe?.servings?.message
+              }
             />
           </div>
-          <FieldError
-            message={
-              form.formState.errors.link?.message ??
-              form.formState.errors.recipe?.servings?.message
-            }
-          />
 
-          <div className="space-y-2">
+          <div className="space-y-1.5">
+            <FieldLabel>Tags</FieldLabel>
             <EditorTags form={form} />
           </div>
 
@@ -260,12 +269,15 @@ export const RecipeEditor = ({
           </div>
 
           <div className="space-y-2 border-t border-[hsl(40_15%_86%)] pt-5">
-            <label htmlFor="recipe-tips" className="font-serif text-base">
-              Tips
+            <label
+              htmlFor="recipe-notes"
+              className="text-muted-foreground block text-[11px] font-bold uppercase tracking-[0.1em]"
+            >
+              Notes
             </label>
             <Textarea
               {...form.register("notes")}
-              id="recipe-tips"
+              id="recipe-notes"
               className="min-h-24 bg-white text-[15px]"
               placeholder="Anything useful to remember next time"
             />
@@ -348,37 +360,40 @@ const PartEditor = ({
           "mt-6 border-t border-[hsl(40_15%_86%)] pt-5",
       )}
     >
-      {multiMode ? (
-        <div className="mb-3 grid grid-cols-[1fr_auto] items-center gap-2">
-          <Input
-            {...form.register(`recipe.parts.${partIndex}.name`)}
-            className="h-10 bg-white font-serif text-base"
-            placeholder="Part name (optional)"
-            aria-label={`Part ${partIndex + 1} name`}
-          />
-          <div className="flex">
-            <IconButton
-              label="Move part up"
-              disabled={!canMoveUp}
-              onClick={onMoveUp}
-            >
-              <ArrowUp />
-            </IconButton>
-            <IconButton
-              label="Move part down"
-              disabled={!canMoveDown}
-              onClick={onMoveDown}
-            >
-              <ArrowDown />
-            </IconButton>
-            <IconButton label="Remove part" destructive onClick={onRemove}>
-              <X />
-            </IconButton>
+      {multiMode && (
+        <div className="mb-4 space-y-1.5">
+          <FieldLabel>Part name</FieldLabel>
+          <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+            <Input
+              {...form.register(`recipe.parts.${partIndex}.name`)}
+              className="h-10 bg-white font-serif text-base"
+              placeholder="Optional"
+              aria-label={`Part ${partIndex + 1} name`}
+            />
+            <div className="flex">
+              <IconButton
+                label="Move part up"
+                disabled={!canMoveUp}
+                onClick={onMoveUp}
+              >
+                <ArrowUp />
+              </IconButton>
+              <IconButton
+                label="Move part down"
+                disabled={!canMoveDown}
+                onClick={onMoveDown}
+              >
+                <ArrowDown />
+              </IconButton>
+              <IconButton label="Remove part" destructive onClick={onRemove}>
+                <X />
+              </IconButton>
+            </div>
           </div>
         </div>
-      ) : (
-        <SectionLabel>Ingredients</SectionLabel>
       )}
+
+      <SectionLabel>Ingredients</SectionLabel>
 
       <div className="mt-2">
         {ingredients.fields.map((ingredient, ingredientIndex) => {
@@ -400,20 +415,13 @@ const PartEditor = ({
                   "rounded-[10px] border-transparent bg-[hsl(40_33%_95%)] shadow-[inset_0_0_0_1px_hsl(18_60%_80%)]",
               )}
             >
-              <div className="grid grid-cols-[52px_58px_1fr_30px] gap-1.5">
+              <div className="grid grid-cols-[60px_58px_1fr_30px] items-start gap-1.5">
                 <input
                   {...form.register(
                     `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.amount`,
-                    {
-                      setValueAs: (value) =>
-                        value === "" ? null : Number(value),
-                    },
                   )}
-                  type="number"
-                  min="0"
-                  step="any"
+                  type="text"
                   inputMode="decimal"
-                  placeholder="0"
                   aria-label={`Ingredient ${ingredientIndex + 1} amount`}
                   className="focus:border-primary focus:ring-primary/15 h-9 min-w-0 rounded-md border bg-white px-1 text-center font-bold outline-none focus:ring-[3px]"
                 />
@@ -440,15 +448,18 @@ const PartEditor = ({
                     </select>
                   )}
                 />
-                <Input
-                  {...form.register(
-                    `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`,
-                  )}
-                  list="recipe-ingredient-names"
-                  className="h-9 min-w-0 bg-white px-2"
-                  placeholder="Ingredient"
-                  aria-label={`Ingredient ${ingredientIndex + 1} name`}
-                />
+                <div className="min-w-0">
+                  <Input
+                    {...form.register(
+                      `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`,
+                    )}
+                    list="recipe-ingredient-names"
+                    className="h-9 min-w-0 bg-white px-2"
+                    placeholder="Ingredient"
+                    aria-label={`Ingredient ${ingredientIndex + 1} name`}
+                  />
+                  <FieldError message={ingredientError?.name?.message} />
+                </div>
                 <button
                   type="button"
                   aria-label={
@@ -457,7 +468,7 @@ const PartEditor = ({
                       : "Show ingredient controls"
                   }
                   className={cn(
-                    "text-muted-foreground flex items-center justify-center rounded-md",
+                    "text-muted-foreground flex h-9 items-center justify-center rounded-md",
                     note && "text-primary",
                   )}
                   onClick={() => toggle(ingredient.id)}
@@ -493,7 +504,6 @@ const PartEditor = ({
               )}
               <FieldError
                 message={
-                  ingredientError?.name?.message ??
                   ingredientError?.amount?.message ??
                   ingredientError?.unit?.message
                 }
@@ -506,7 +516,7 @@ const PartEditor = ({
           label="Add ingredient"
           onClick={() =>
             ingredients.append({
-              amount: null,
+              amount: "",
               unit: null,
               name: "",
               note: "",
@@ -620,6 +630,21 @@ const EditorTags = ({ form }: { form: UseFormReturn<RecipeEditorValues> }) => {
     />
   );
 };
+
+const FieldLabel = ({
+  htmlFor,
+  children,
+}: {
+  htmlFor?: string;
+  children: React.ReactNode;
+}) => (
+  <label
+    htmlFor={htmlFor}
+    className="text-muted-foreground block text-xs font-semibold"
+  >
+    {children}
+  </label>
+);
 
 const SectionLabel = ({ children }: { children: React.ReactNode }) => (
   <h2 className="text-muted-foreground text-[11px] font-bold uppercase tracking-[0.1em]">

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -32,7 +32,7 @@ import { FancyCombobox } from "../../components/ui/FancyCombobox";
 import { DeleteDinnerButton } from "./DeleteDinnerButton";
 
 const editorIngredientSchema = recipeIngredientSchema.extend({
-  name: z.string().trim().min(1, "Name this ingredient or remove the row"),
+  name: z.string().trim().min(1, "Name required"),
   amount: z.number().positive("Amount must be more than 0").nullable(),
   note: z.string(),
 });

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -383,7 +383,7 @@ const PartEditor = ({
     >
       {multiMode && (
         <div className="mb-4 space-y-1.5">
-          <FieldLabel>Part name</FieldLabel>
+          <FieldLabel>Part</FieldLabel>
           <div className="grid grid-cols-[1fr_auto] items-center gap-2">
             <Input
               {...form.register(`recipe.parts.${partIndex}.name`)}

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -1,0 +1,716 @@
+import { type CSSProperties, useEffect, useRef, useState } from "react";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Controller,
+  type UseFormReturn,
+  useFieldArray,
+  useForm,
+} from "react-hook-form";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Minus,
+  Plus,
+  X,
+} from "lucide-react";
+import {
+  UNITS,
+  type DinnerWithRecipe,
+  recipeIngredientSchema,
+} from "@planeatrepeat/shared";
+import { api } from "../../utils/api";
+import { cn } from "../../lib/utils";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import { Textarea } from "../../components/ui/textarea";
+import { Form } from "../../components/ui/form";
+import { FancyCombobox } from "../../components/ui/FancyCombobox";
+import { DeleteDinnerButton } from "./DeleteDinnerButton";
+
+const editorIngredientSchema = recipeIngredientSchema.extend({
+  note: z.string(),
+});
+
+const recipeEditorSchema = z.object({
+  name: z.string().trim().min(1, "Add a dinner name"),
+  tags: z.array(z.string()),
+  newTag: z.string().optional(),
+  link: z.union([z.literal(""), z.string().url("Enter a valid URL")]),
+  notes: z.string(),
+  recipe: z.object({
+    servings: z.number().int().positive().nullable(),
+    parts: z.array(
+      z.object({
+        name: z.string(),
+        ingredients: z.array(editorIngredientSchema),
+        steps: z.array(
+          z.object({
+            text: z.string().trim().min(1, "Add a step or remove this row"),
+          }),
+        ),
+      }),
+    ),
+  }),
+});
+
+export type RecipeEditorValues = z.infer<typeof recipeEditorSchema>;
+
+type Props = {
+  dinner: DinnerWithRecipe;
+  isPending: boolean;
+  onCancel: () => void;
+  onSave: (values: RecipeEditorValues) => void;
+  onDelete: () => void;
+};
+
+const emptyPart = (): RecipeEditorValues["recipe"]["parts"][number] => ({
+  name: "",
+  ingredients: [],
+  steps: [],
+});
+
+export const RecipeEditor = ({
+  dinner,
+  isPending,
+  onCancel,
+  onSave,
+  onDelete,
+}: Props) => {
+  const form = useForm<RecipeEditorValues>({
+    resolver: zodResolver(recipeEditorSchema),
+    defaultValues: {
+      name: dinner.name,
+      tags: dinner.tags.map((tag) => tag.value),
+      newTag: "",
+      link: dinner.link ?? "",
+      notes: dinner.notes ?? "",
+      recipe: {
+        servings: dinner.servings,
+        parts: dinner.parts.map((part) => ({
+          name: part.name ?? "",
+          ingredients: part.ingredients.map((ingredient) => ({
+            name: ingredient.name,
+            amount: ingredient.amount,
+            unit: UNITS.find((unit) => unit === ingredient.unit) ?? null,
+            note: ingredient.note ?? "",
+          })),
+          steps: part.steps.map((step) => ({ text: step.text })),
+        })),
+      },
+    },
+  });
+  const parts = useFieldArray({
+    control: form.control,
+    name: "recipe.parts",
+  });
+  const watchedParts = form.watch("recipe.parts");
+  const servings = form.watch("recipe.servings");
+  const multiMode =
+    watchedParts.length > 1 ||
+    watchedParts.some((part) => part.name.trim().length > 0);
+  const ingredientNamesQuery = api.dinner.ingredientNames.useQuery();
+
+  const cancel = () => {
+    if (
+      !form.formState.isDirty ||
+      window.confirm("Discard your unsaved changes?")
+    ) {
+      onCancel();
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSave)}
+        className="mx-auto w-full max-w-[640px] pb-6"
+      >
+        <div className="bg-background/95 sticky top-0 z-20 -mx-4 mb-5 grid grid-cols-[1fr_auto_1fr] items-center border-b px-4 py-2 backdrop-blur">
+          <Button
+            type="button"
+            variant="ghost"
+            className="justify-self-start px-2"
+            onClick={cancel}
+          >
+            Cancel
+          </Button>
+          <h1 className="font-serif text-base font-normal">Edit recipe</h1>
+          <Button
+            type="submit"
+            size="sm"
+            className="justify-self-end"
+            disabled={isPending}
+          >
+            {isPending && <Loader2 className="animate-spin" />}
+            Save
+          </Button>
+        </div>
+
+        <div className="space-y-5">
+          <div>
+            <Input
+              {...form.register("name")}
+              aria-label="Dinner name"
+              className="h-12 bg-white text-lg font-semibold"
+              placeholder="Dinner name"
+            />
+            <FieldError message={form.formState.errors.name?.message} />
+          </div>
+
+          <div className="grid grid-cols-[116px_1fr] gap-2">
+            <div
+              className="grid h-10 grid-cols-[32px_1fr_32px] overflow-hidden rounded-md border bg-white"
+              aria-label="Servings"
+            >
+              <button
+                type="button"
+                aria-label="Decrease servings"
+                className="text-muted-foreground hover:bg-accent flex items-center justify-center border-r"
+                onClick={() =>
+                  form.setValue(
+                    "recipe.servings",
+                    Math.max(1, (servings ?? 2) - 1),
+                    { shouldDirty: true },
+                  )
+                }
+              >
+                <Minus className="h-3.5 w-3.5" />
+              </button>
+              <input
+                {...form.register("recipe.servings", {
+                  setValueAs: (value) => (value === "" ? null : Number(value)),
+                })}
+                className="min-w-0 bg-transparent text-center font-bold outline-none"
+                type="number"
+                min={1}
+                inputMode="numeric"
+                placeholder="–"
+                aria-label="Number of servings"
+              />
+              <button
+                type="button"
+                aria-label="Increase servings"
+                className="text-muted-foreground hover:bg-accent flex items-center justify-center border-l"
+                onClick={() =>
+                  form.setValue("recipe.servings", (servings ?? 0) + 1, {
+                    shouldDirty: true,
+                  })
+                }
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <Input
+              {...form.register("link")}
+              type="url"
+              className="bg-white"
+              placeholder="Recipe link"
+              aria-label="Recipe link"
+            />
+          </div>
+          <FieldError
+            message={
+              form.formState.errors.link?.message ??
+              form.formState.errors.recipe?.servings?.message
+            }
+          />
+
+          <div className="space-y-2">
+            <EditorTags form={form} />
+          </div>
+
+          <div className="border-t border-[hsl(40_15%_86%)] pt-5">
+            {parts.fields.map((part, partIndex) => (
+              <PartEditor
+                key={part.id}
+                form={form}
+                partIndex={partIndex}
+                multiMode={multiMode}
+                ingredientNames={
+                  ingredientNamesQuery.data?.ingredientNames ?? []
+                }
+                canMoveUp={partIndex > 0}
+                canMoveDown={partIndex < parts.fields.length - 1}
+                onMoveUp={() => parts.move(partIndex, partIndex - 1)}
+                onMoveDown={() => parts.move(partIndex, partIndex + 1)}
+                onRemove={() => parts.remove(partIndex)}
+              />
+            ))}
+
+            <Button
+              type="button"
+              variant="secondary"
+              className="text-primary mt-4 w-full font-serif font-normal"
+              onClick={() => parts.append(emptyPart())}
+            >
+              <Plus />
+              {parts.fields.length === 0 ? "Add recipe" : "Add part"}
+            </Button>
+          </div>
+
+          <div className="space-y-2 border-t border-[hsl(40_15%_86%)] pt-5">
+            <label htmlFor="recipe-tips" className="font-serif text-base">
+              Tips
+            </label>
+            <Textarea
+              {...form.register("notes")}
+              id="recipe-tips"
+              className="min-h-24 bg-white text-[15px]"
+              placeholder="Anything useful to remember next time"
+            />
+          </div>
+
+          <DeleteDinnerButton
+            dinnerId={dinner.id}
+            isPending={isPending}
+            onDelete={onDelete}
+          />
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+type PartEditorProps = {
+  form: UseFormReturn<RecipeEditorValues>;
+  partIndex: number;
+  multiMode: boolean;
+  ingredientNames: string[];
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+};
+
+const PartEditor = ({
+  form,
+  partIndex,
+  multiMode,
+  ingredientNames,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+}: PartEditorProps) => {
+  const ingredients = useFieldArray({
+    control: form.control,
+    name: `recipe.parts.${partIndex}.ingredients`,
+  });
+  const steps = useFieldArray({
+    control: form.control,
+    name: `recipe.parts.${partIndex}.steps`,
+  });
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const knownIds = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    const ids = [...ingredients.fields, ...steps.fields].map(
+      (field) => field.id,
+    );
+    if (knownIds.current === null) {
+      knownIds.current = new Set(ids);
+      return;
+    }
+
+    const newIds = ids.filter((id) => !knownIds.current?.has(id));
+    if (newIds.length > 0) {
+      setExpanded((current) => new Set([...current, ...newIds]));
+      knownIds.current = new Set(ids);
+    }
+  }, [ingredients.fields, steps.fields]);
+
+  const open = (id: string) =>
+    setExpanded((current) => new Set(current).add(id));
+  const toggle = (id: string) =>
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  return (
+    <section
+      className={cn(
+        partIndex > 0 &&
+          multiMode &&
+          "mt-6 border-t border-[hsl(40_15%_86%)] pt-5",
+      )}
+    >
+      {multiMode ? (
+        <div className="mb-3 grid grid-cols-[1fr_auto] items-center gap-2">
+          <Input
+            {...form.register(`recipe.parts.${partIndex}.name`)}
+            className="h-10 bg-white font-serif text-base"
+            placeholder="Part name (optional)"
+            aria-label={`Part ${partIndex + 1} name`}
+          />
+          <div className="flex">
+            <IconButton
+              label="Move part up"
+              disabled={!canMoveUp}
+              onClick={onMoveUp}
+            >
+              <ArrowUp />
+            </IconButton>
+            <IconButton
+              label="Move part down"
+              disabled={!canMoveDown}
+              onClick={onMoveDown}
+            >
+              <ArrowDown />
+            </IconButton>
+            <IconButton label="Remove part" destructive onClick={onRemove}>
+              <X />
+            </IconButton>
+          </div>
+        </div>
+      ) : (
+        <SectionLabel>Ingredients</SectionLabel>
+      )}
+
+      <div className="mt-2">
+        {ingredients.fields.map((ingredient, ingredientIndex) => {
+          const isExpanded = expanded.has(ingredient.id);
+          const note = form.watch(
+            `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.note`,
+          );
+          const ingredientError =
+            form.formState.errors.recipe?.parts?.[partIndex]?.ingredients?.[
+              ingredientIndex
+            ];
+
+          return (
+            <div
+              key={ingredient.id}
+              className={cn(
+                "border-b border-[hsl(40_15%_92%)] px-1 py-2",
+                isExpanded &&
+                  "rounded-[10px] border-transparent bg-[hsl(40_33%_95%)] shadow-[inset_0_0_0_1px_hsl(18_60%_80%)]",
+              )}
+            >
+              <div className="grid grid-cols-[52px_58px_1fr_30px] gap-1.5">
+                <input
+                  {...form.register(
+                    `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.amount`,
+                    {
+                      setValueAs: (value) =>
+                        value === "" ? null : Number(value),
+                    },
+                  )}
+                  type="number"
+                  min="0"
+                  step="any"
+                  inputMode="decimal"
+                  placeholder="0"
+                  aria-label={`Ingredient ${ingredientIndex + 1} amount`}
+                  className="focus:border-primary focus:ring-primary/15 h-9 min-w-0 rounded-md border bg-white px-1 text-center font-bold outline-none focus:ring-[3px]"
+                />
+                <Controller
+                  control={form.control}
+                  name={`recipe.parts.${partIndex}.ingredients.${ingredientIndex}.unit`}
+                  render={({ field }) => (
+                    <select
+                      ref={field.ref}
+                      value={field.value ?? ""}
+                      onBlur={field.onBlur}
+                      onChange={(event) =>
+                        field.onChange(event.target.value || null)
+                      }
+                      aria-label={`Ingredient ${ingredientIndex + 1} unit`}
+                      className="focus:border-primary focus:ring-primary/15 h-9 min-w-0 rounded-md border bg-white px-1 text-center text-sm outline-none focus:ring-[3px]"
+                    >
+                      <option value="">–</option>
+                      {UNITS.map((unit) => (
+                        <option key={unit} value={unit}>
+                          {unit}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                />
+                <Input
+                  {...form.register(
+                    `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.name`,
+                  )}
+                  list="recipe-ingredient-names"
+                  className="h-9 min-w-0 bg-white px-2"
+                  placeholder="Ingredient"
+                  aria-label={`Ingredient ${ingredientIndex + 1} name`}
+                />
+                <button
+                  type="button"
+                  aria-label={
+                    isExpanded
+                      ? "Hide ingredient controls"
+                      : "Show ingredient controls"
+                  }
+                  className={cn(
+                    "text-muted-foreground flex items-center justify-center rounded-md",
+                    note && "text-primary",
+                  )}
+                  onClick={() => toggle(ingredient.id)}
+                >
+                  {isExpanded ? <ChevronDown /> : <ChevronRight />}
+                </button>
+              </div>
+
+              {isExpanded && (
+                <div className="mt-2 space-y-2">
+                  <Input
+                    {...form.register(
+                      `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.note`,
+                    )}
+                    className="h-9 bg-white text-sm"
+                    placeholder="note — e.g. grated, cut in strips"
+                    aria-label={`Ingredient ${ingredientIndex + 1} note`}
+                  />
+                  <RowControls
+                    canMoveUp={ingredientIndex > 0}
+                    canMoveDown={
+                      ingredientIndex < ingredients.fields.length - 1
+                    }
+                    onMoveUp={() =>
+                      ingredients.move(ingredientIndex, ingredientIndex - 1)
+                    }
+                    onMoveDown={() =>
+                      ingredients.move(ingredientIndex, ingredientIndex + 1)
+                    }
+                    onRemove={() => ingredients.remove(ingredientIndex)}
+                  />
+                </div>
+              )}
+              <FieldError
+                message={
+                  ingredientError?.name?.message ??
+                  ingredientError?.amount?.message ??
+                  ingredientError?.unit?.message
+                }
+              />
+            </div>
+          );
+        })}
+
+        <datalist id="recipe-ingredient-names">
+          {ingredientNames.map((name) => (
+            <option key={name} value={name} />
+          ))}
+        </datalist>
+
+        <AddButton
+          label="Add ingredient"
+          onClick={() =>
+            ingredients.append({
+              amount: null,
+              unit: null,
+              name: "",
+              note: "",
+            })
+          }
+        />
+      </div>
+
+      <div className="mt-5">
+        <SectionLabel>Steps</SectionLabel>
+        <div className="mt-2">
+          {steps.fields.map((step, stepIndex) => {
+            const isExpanded = expanded.has(step.id);
+            const stepError =
+              form.formState.errors.recipe?.parts?.[partIndex]?.steps?.[
+                stepIndex
+              ]?.text?.message;
+
+            return (
+              <div
+                key={step.id}
+                className={cn(
+                  "border-b border-[hsl(40_15%_92%)] px-1 py-2",
+                  isExpanded &&
+                    "rounded-[10px] border-transparent bg-[hsl(40_33%_95%)] shadow-[inset_0_0_0_1px_hsl(18_60%_80%)]",
+                )}
+              >
+                <div className="grid grid-cols-[18px_1fr] gap-2">
+                  <span className="pt-2 font-serif text-[hsl(18_75%_50%)]">
+                    {stepIndex + 1}
+                  </span>
+                  <Textarea
+                    {...form.register(
+                      `recipe.parts.${partIndex}.steps.${stepIndex}.text`,
+                    )}
+                    className="min-h-10 resize-none overflow-hidden bg-white py-2 text-[15px]"
+                    placeholder="Describe this step"
+                    aria-label={`Step ${stepIndex + 1}`}
+                    onFocus={() => open(step.id)}
+                    onInput={(event) => {
+                      event.currentTarget.style.height = "auto";
+                      event.currentTarget.style.height = `${event.currentTarget.scrollHeight}px`;
+                    }}
+                    style={{ fieldSizing: "content" } as CSSProperties}
+                  />
+                </div>
+                {isExpanded && (
+                  <div className="ml-[26px] mt-2">
+                    <RowControls
+                      canMoveUp={stepIndex > 0}
+                      canMoveDown={stepIndex < steps.fields.length - 1}
+                      onMoveUp={() => steps.move(stepIndex, stepIndex - 1)}
+                      onMoveDown={() => steps.move(stepIndex, stepIndex + 1)}
+                      onRemove={() => steps.remove(stepIndex)}
+                    />
+                  </div>
+                )}
+                <div className="ml-[26px]">
+                  <FieldError message={stepError} />
+                </div>
+              </div>
+            );
+          })}
+          <AddButton
+            label="Add step"
+            onClick={() => steps.append({ text: "" })}
+          />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const EditorTags = ({ form }: { form: UseFormReturn<RecipeEditorValues> }) => {
+  const tagsQuery = api.dinner.tags.useQuery(undefined, {
+    select: (data) =>
+      data.tags.map((tag) => ({ value: tag.value, label: tag.value })),
+  });
+  const selected = form.watch("tags").map((tag) => ({
+    value: tag,
+    label: tag,
+  }));
+
+  return (
+    <FancyCombobox
+      options={tagsQuery.data ?? []}
+      placeholder="Add tag…"
+      selected={selected}
+      select={(option) =>
+        form.setValue("tags", [...form.getValues("tags"), option.value], {
+          shouldDirty: true,
+        })
+      }
+      unselect={(option) =>
+        form.setValue(
+          "tags",
+          form.getValues("tags").filter((tag) => tag !== option.value),
+          { shouldDirty: true },
+        )
+      }
+      removeLast={() =>
+        form.setValue("tags", form.getValues("tags").slice(0, -1), {
+          shouldDirty: true,
+        })
+      }
+      createNew={(value) =>
+        form.setValue("tags", [...form.getValues("tags"), value], {
+          shouldDirty: true,
+        })
+      }
+    />
+  );
+};
+
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <h2 className="text-muted-foreground text-[11px] font-bold uppercase tracking-[0.1em]">
+    {children}
+  </h2>
+);
+
+const AddButton = ({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) => (
+  <Button
+    type="button"
+    variant="outline"
+    className="text-primary mt-2 h-9 w-full border-dashed border-[hsl(40_15%_80%)] bg-transparent"
+    onClick={onClick}
+  >
+    <Plus />
+    {label}
+  </Button>
+);
+
+const IconButton = ({
+  label,
+  children,
+  disabled,
+  destructive,
+  onClick,
+}: {
+  label: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+  destructive?: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    aria-label={label}
+    title={label}
+    disabled={disabled}
+    className={cn(
+      "text-muted-foreground hover:bg-accent flex h-9 w-8 items-center justify-center rounded-md disabled:opacity-30",
+      destructive && "text-destructive",
+    )}
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);
+
+const RowControls = ({
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+}: {
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+}) => (
+  <div className="flex items-center justify-between">
+    <div className="flex">
+      <IconButton label="Move up" disabled={!canMoveUp} onClick={onMoveUp}>
+        <ArrowUp />
+      </IconButton>
+      <IconButton
+        label="Move down"
+        disabled={!canMoveDown}
+        onClick={onMoveDown}
+      >
+        <ArrowDown />
+      </IconButton>
+    </div>
+    <button
+      type="button"
+      className="text-destructive px-2 py-1 text-sm font-semibold"
+      onClick={onRemove}
+    >
+      Remove
+    </button>
+  </div>
+);
+
+const FieldError = ({ message }: { message?: string }) =>
+  message ? (
+    <p className="text-destructive mt-1 text-xs font-medium">{message}</p>
+  ) : null;

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -369,8 +369,17 @@ const PartEditor = ({
       }
     };
 
-    document.addEventListener("click", collapse);
-    return () => document.removeEventListener("click", collapse);
+    // Register after the current event finishes dispatching: React can flush
+    // this effect mid-click (e.g. the add-row click that expands the new
+    // row), and the listener would otherwise see that same click as being
+    // outside the row and collapse it again.
+    const timeout = window.setTimeout(() =>
+      document.addEventListener("click", collapse),
+    );
+    return () => {
+      window.clearTimeout(timeout);
+      document.removeEventListener("click", collapse);
+    };
   }, [expandedId]);
 
   return (
@@ -491,10 +500,7 @@ const PartEditor = ({
                   }
                   aria-expanded={isExpanded}
                   className="text-muted-foreground flex h-9 items-center justify-center rounded-md [&_svg]:pointer-events-none"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    toggle(ingredient.id);
-                  }}
+                  onClick={() => toggle(ingredient.id)}
                 >
                   {isExpanded ? <ChevronDown /> : <ChevronRight />}
                 </button>
@@ -593,10 +599,7 @@ const PartEditor = ({
                     }
                     aria-expanded={isExpanded}
                     className="text-muted-foreground flex h-10 items-center justify-center rounded-md [&_svg]:pointer-events-none"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      toggle(step.id);
-                    }}
+                    onClick={() => toggle(step.id)}
                   >
                     {isExpanded ? <ChevronDown /> : <ChevronRight />}
                   </button>

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -32,6 +32,8 @@ import { FancyCombobox } from "../../components/ui/FancyCombobox";
 import { DeleteDinnerButton } from "./DeleteDinnerButton";
 
 const editorIngredientSchema = recipeIngredientSchema.extend({
+  name: z.string().trim().min(1, "Name this ingredient or remove the row"),
+  amount: z.number().positive("Amount must be more than 0").nullable(),
   note: z.string(),
 });
 
@@ -230,9 +232,6 @@ export const RecipeEditor = ({
                 form={form}
                 partIndex={partIndex}
                 multiMode={multiMode}
-                ingredientNames={
-                  ingredientNamesQuery.data?.ingredientNames ?? []
-                }
                 canMoveUp={partIndex > 0}
                 canMoveDown={partIndex < parts.fields.length - 1}
                 onMoveUp={() => parts.move(partIndex, partIndex - 1)}
@@ -250,6 +249,14 @@ export const RecipeEditor = ({
               <Plus />
               {parts.fields.length === 0 ? "Add recipe" : "Add part"}
             </Button>
+
+            <datalist id="recipe-ingredient-names">
+              {(ingredientNamesQuery.data?.ingredientNames ?? []).map(
+                (name) => (
+                  <option key={name} value={name} />
+                ),
+              )}
+            </datalist>
           </div>
 
           <div className="space-y-2 border-t border-[hsl(40_15%_86%)] pt-5">
@@ -279,7 +286,6 @@ type PartEditorProps = {
   form: UseFormReturn<RecipeEditorValues>;
   partIndex: number;
   multiMode: boolean;
-  ingredientNames: string[];
   canMoveUp: boolean;
   canMoveDown: boolean;
   onMoveUp: () => void;
@@ -291,7 +297,6 @@ const PartEditor = ({
   form,
   partIndex,
   multiMode,
-  ingredientNames,
   canMoveUp,
   canMoveDown,
   onMoveUp,
@@ -496,12 +501,6 @@ const PartEditor = ({
             </div>
           );
         })}
-
-        <datalist id="recipe-ingredient-names">
-          {ingredientNames.map((name) => (
-            <option key={name} value={name} />
-          ))}
-        </datalist>
 
         <AddButton
           label="Add ingredient"

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -156,82 +156,84 @@ export const RecipeEditor = ({
         </div>
 
         <div className="space-y-5">
-          <div className="space-y-1.5">
-            <FieldLabel htmlFor="dinner-name">Name</FieldLabel>
-            <Input
-              {...form.register("name")}
-              id="dinner-name"
-              className="h-12 bg-white text-lg font-semibold"
-            />
-            <FieldError message={form.formState.errors.name?.message} />
-          </div>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <FieldLabel htmlFor="dinner-name">Name</FieldLabel>
+              <Input
+                {...form.register("name")}
+                id="dinner-name"
+                className="h-12 bg-white text-lg font-semibold"
+              />
+              <FieldError message={form.formState.errors.name?.message} />
+            </div>
 
-          <div>
-            <div className="grid grid-cols-[116px_1fr] gap-2">
-              <div className="space-y-1.5">
-                <FieldLabel>Servings</FieldLabel>
-                <div className="grid h-10 grid-cols-[32px_1fr_32px] overflow-hidden rounded-md border bg-white">
-                  <button
-                    type="button"
-                    aria-label="Decrease servings"
-                    className="text-muted-foreground hover:bg-accent flex items-center justify-center border-r"
-                    onClick={() =>
-                      form.setValue(
-                        "recipe.servings",
-                        Math.max(1, (servings ?? 2) - 1),
-                        { shouldDirty: true },
-                      )
-                    }
-                  >
-                    <Minus className="h-3.5 w-3.5" />
-                  </button>
-                  <input
-                    {...form.register("recipe.servings", {
-                      setValueAs: (value) =>
-                        value === "" ? null : Number(value),
-                    })}
-                    className="min-w-0 bg-transparent text-center font-bold outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                    type="number"
-                    min={1}
-                    inputMode="numeric"
-                    placeholder="–"
-                    aria-label="Number of servings"
+            <div>
+              <div className="grid grid-cols-[116px_1fr] gap-2">
+                <div className="space-y-1.5">
+                  <FieldLabel>Servings</FieldLabel>
+                  <div className="grid h-10 grid-cols-[32px_1fr_32px] overflow-hidden rounded-md border bg-white">
+                    <button
+                      type="button"
+                      aria-label="Decrease servings"
+                      className="text-muted-foreground hover:bg-accent flex items-center justify-center border-r"
+                      onClick={() =>
+                        form.setValue(
+                          "recipe.servings",
+                          Math.max(1, (servings ?? 2) - 1),
+                          { shouldDirty: true },
+                        )
+                      }
+                    >
+                      <Minus className="h-3.5 w-3.5" />
+                    </button>
+                    <input
+                      {...form.register("recipe.servings", {
+                        setValueAs: (value) =>
+                          value === "" ? null : Number(value),
+                      })}
+                      className="min-w-0 bg-transparent text-center font-bold outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                      type="number"
+                      min={1}
+                      inputMode="numeric"
+                      placeholder="–"
+                      aria-label="Number of servings"
+                    />
+                    <button
+                      type="button"
+                      aria-label="Increase servings"
+                      className="text-muted-foreground hover:bg-accent flex items-center justify-center border-l"
+                      onClick={() =>
+                        form.setValue("recipe.servings", (servings ?? 0) + 1, {
+                          shouldDirty: true,
+                        })
+                      }
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+                <div className="space-y-1.5">
+                  <FieldLabel htmlFor="recipe-link">Recipe link</FieldLabel>
+                  <Input
+                    {...form.register("link")}
+                    id="recipe-link"
+                    type="url"
+                    className="bg-white"
                   />
-                  <button
-                    type="button"
-                    aria-label="Increase servings"
-                    className="text-muted-foreground hover:bg-accent flex items-center justify-center border-l"
-                    onClick={() =>
-                      form.setValue("recipe.servings", (servings ?? 0) + 1, {
-                        shouldDirty: true,
-                      })
-                    }
-                  >
-                    <Plus className="h-3.5 w-3.5" />
-                  </button>
                 </div>
               </div>
-              <div className="space-y-1.5">
-                <FieldLabel htmlFor="recipe-link">Recipe link</FieldLabel>
-                <Input
-                  {...form.register("link")}
-                  id="recipe-link"
-                  type="url"
-                  className="bg-white"
-                />
-              </div>
+              <FieldError
+                message={
+                  form.formState.errors.link?.message ??
+                  form.formState.errors.recipe?.servings?.message
+                }
+              />
             </div>
-            <FieldError
-              message={
-                form.formState.errors.link?.message ??
-                form.formState.errors.recipe?.servings?.message
-              }
-            />
-          </div>
 
-          <div className="space-y-1.5">
-            <FieldLabel>Tags</FieldLabel>
-            <EditorTags form={form} />
+            <div className="space-y-1.5">
+              <FieldLabel>Tags</FieldLabel>
+              <EditorTags form={form} />
+            </div>
           </div>
 
           <div className="border-t border-[hsl(40_15%_86%)] pt-5">
@@ -323,7 +325,9 @@ const PartEditor = ({
     control: form.control,
     name: `recipe.parts.${partIndex}.steps`,
   });
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  // Only one row is expanded at a time, so focusing or expanding another
+  // row contracts the previous one; clicking outside a row contracts it too.
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const knownIds = useRef<Set<string> | null>(null);
 
   useEffect(() => {
@@ -337,20 +341,20 @@ const PartEditor = ({
 
     const newIds = ids.filter((id) => !knownIds.current?.has(id));
     if (newIds.length > 0) {
-      setExpanded((current) => new Set([...current, ...newIds]));
+      setExpandedId(newIds[newIds.length - 1] ?? null);
       knownIds.current = new Set(ids);
     }
   }, [ingredients.fields, steps.fields]);
 
-  const open = (id: string) =>
-    setExpanded((current) => new Set(current).add(id));
+  const open = (id: string) => setExpandedId(id);
   const toggle = (id: string) =>
-    setExpanded((current) => {
-      const next = new Set(current);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+    setExpandedId((current) => (current === id ? null : id));
+  const collapseOnBlur =
+    (id: string) => (event: React.FocusEvent<HTMLDivElement>) => {
+      if (!event.currentTarget.contains(event.relatedTarget)) {
+        setExpandedId((current) => (current === id ? null : current));
+      }
+    };
 
   return (
     <section
@@ -395,9 +399,9 @@ const PartEditor = ({
 
       <SectionLabel>Ingredients</SectionLabel>
 
-      <div className="mt-2">
+      <div className="mt-1">
         {ingredients.fields.map((ingredient, ingredientIndex) => {
-          const isExpanded = expanded.has(ingredient.id);
+          const isExpanded = expandedId === ingredient.id;
           const note = form.watch(
             `recipe.parts.${partIndex}.ingredients.${ingredientIndex}.note`,
           );
@@ -409,8 +413,9 @@ const PartEditor = ({
           return (
             <div
               key={ingredient.id}
+              onBlur={collapseOnBlur(ingredient.id)}
               className={cn(
-                "border-b border-[hsl(40_15%_92%)] px-1 py-2",
+                "border-b border-[hsl(40_15%_92%)] px-1 py-1.5",
                 isExpanded &&
                   "rounded-[10px] border-transparent bg-[hsl(40_33%_95%)] shadow-[inset_0_0_0_1px_hsl(18_60%_80%)]",
               )}
@@ -527,9 +532,9 @@ const PartEditor = ({
 
       <div className="mt-5">
         <SectionLabel>Steps</SectionLabel>
-        <div className="mt-2">
+        <div className="mt-1">
           {steps.fields.map((step, stepIndex) => {
-            const isExpanded = expanded.has(step.id);
+            const isExpanded = expandedId === step.id;
             const stepError =
               form.formState.errors.recipe?.parts?.[partIndex]?.steps?.[
                 stepIndex
@@ -538,13 +543,14 @@ const PartEditor = ({
             return (
               <div
                 key={step.id}
+                onBlur={collapseOnBlur(step.id)}
                 className={cn(
-                  "border-b border-[hsl(40_15%_92%)] px-1 py-2",
+                  "border-b border-[hsl(40_15%_92%)] px-1 py-1.5",
                   isExpanded &&
                     "rounded-[10px] border-transparent bg-[hsl(40_33%_95%)] shadow-[inset_0_0_0_1px_hsl(18_60%_80%)]",
                 )}
               >
-                <div className="grid grid-cols-[18px_1fr] gap-2">
+                <div className="grid grid-cols-[18px_1fr_30px] items-start gap-2">
                   <span className="pt-2 font-serif text-[hsl(18_75%_50%)]">
                     {stepIndex + 1}
                   </span>
@@ -562,6 +568,16 @@ const PartEditor = ({
                     }}
                     style={{ fieldSizing: "content" } as CSSProperties}
                   />
+                  <button
+                    type="button"
+                    aria-label={
+                      isExpanded ? "Hide step controls" : "Show step controls"
+                    }
+                    className="text-muted-foreground flex h-10 items-center justify-center rounded-md"
+                    onClick={() => toggle(step.id)}
+                  >
+                    {isExpanded ? <ChevronDown /> : <ChevronRight />}
+                  </button>
                 </div>
                 {isExpanded && (
                   <div className="ml-[26px] mt-2">

--- a/apps/web/src/views/Dinners/RecipeView.tsx
+++ b/apps/web/src/views/Dinners/RecipeView.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import { ExternalLink } from "lucide-react";
 import { formatAmount, type DinnerWithRecipe } from "@planeatrepeat/shared";
 import { Button } from "../../components/ui/button";
@@ -81,18 +82,22 @@ export const RecipeView = ({ dinner, onEdit }: Props) => {
               key={part.id}
               className={
                 partIndex > 0
-                  ? "mt-[26px] border-t border-[hsl(40_15%_86%)]"
+                  ? "mt-[26px] border-t border-[hsl(40_15%_86%)] pt-5"
                   : undefined
               }
             >
               {part.name && (
-                <h2 className="mt-[22px] font-serif text-xl font-normal">
-                  {part.name}
-                </h2>
+                <h2 className="font-serif text-xl font-normal">{part.name}</h2>
               )}
 
               {part.ingredients.length > 0 && (
-                <div className={part.name ? "mt-2.5" : "mt-0"}>
+                // max-content sizes the amount column to the part's longest
+                // amount, and collapses it when no ingredient has one.
+                <div
+                  className={`grid grid-cols-[max-content_1fr] gap-x-2.5 gap-y-1 text-base leading-[1.3] ${
+                    part.name ? "mt-2.5" : "mt-0"
+                  }`}
+                >
                   {part.ingredients.map((ingredient) => {
                     const amount = [
                       ingredient.amount === null
@@ -104,10 +109,7 @@ export const RecipeView = ({ dinner, onEdit }: Props) => {
                       .join(" ");
 
                     return (
-                      <div
-                        key={ingredient.id}
-                        className="grid grid-cols-[74px_1fr] gap-2.5 py-0.5 text-base leading-[1.3]"
-                      >
+                      <Fragment key={ingredient.id}>
                         <span className="font-bold">{amount}</span>
                         <span className="font-medium">
                           {ingredient.name}
@@ -118,7 +120,7 @@ export const RecipeView = ({ dinner, onEdit }: Props) => {
                             </span>
                           )}
                         </span>
-                      </div>
+                      </Fragment>
                     );
                   })}
                 </div>
@@ -151,8 +153,8 @@ export const RecipeView = ({ dinner, onEdit }: Props) => {
       )}
 
       {dinner.notes && (
-        <section className="mt-[26px] border-t border-[hsl(40_15%_86%)]">
-          <h2 className="mb-1.5 mt-5 font-serif text-base font-normal">Tips</h2>
+        <section className="mt-[26px] border-t border-[hsl(40_15%_86%)] pt-5">
+          <h2 className="mb-1.5 font-serif text-base font-normal">Notes</h2>
           <p className="whitespace-pre-wrap text-[15px] font-medium leading-[1.5] text-[hsl(24_10%_25%)]">
             {dinner.notes}
           </p>

--- a/apps/web/src/views/Dinners/RecipeView.tsx
+++ b/apps/web/src/views/Dinners/RecipeView.tsx
@@ -1,0 +1,163 @@
+import { ExternalLink } from "lucide-react";
+import { formatAmount, type DinnerWithRecipe } from "@planeatrepeat/shared";
+import { Button } from "../../components/ui/button";
+
+type Props = {
+  dinner: DinnerWithRecipe;
+  onEdit: () => void;
+};
+
+const sourceLabel = (link: string) => {
+  try {
+    return new URL(link).hostname.replace(/^www\./, "");
+  } catch {
+    return link;
+  }
+};
+
+export const RecipeView = ({ dinner, onEdit }: Props) => {
+  const hasRecipe = dinner.parts.length > 0;
+
+  return (
+    <article className="mx-auto w-full max-w-[640px] px-1 pb-6">
+      <header className="space-y-3">
+        <div className="flex items-start gap-3">
+          <h1 className="min-w-0 flex-1 font-serif text-[26px] font-normal leading-[1.2]">
+            {dinner.name}
+          </h1>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="text-muted-foreground h-auto bg-white px-3 py-1.5 text-[13px] font-semibold"
+            onClick={onEdit}
+          >
+            Edit
+          </Button>
+        </div>
+
+        {dinner.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {dinner.tags.map((tag) => (
+              <span
+                key={tag.value}
+                className="text-muted-foreground rounded-full border bg-white px-2.5 py-[3px] text-xs font-semibold"
+              >
+                {tag.value}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {(dinner.link !== null || dinner.servings !== null) && (
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            {dinner.link && (
+              <a
+                href={dinner.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-semibold text-[hsl(18_75%_45%)]"
+              >
+                {sourceLabel(dinner.link)}
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+            {dinner.link && dinner.servings && (
+              <span className="text-[hsl(40_15%_78%)]">·</span>
+            )}
+            {dinner.servings && (
+              <span className="text-muted-foreground font-medium">
+                {dinner.servings} servings
+              </span>
+            )}
+          </div>
+        )}
+      </header>
+
+      {hasRecipe ? (
+        <div className="mt-6">
+          {dinner.parts.map((part, partIndex) => (
+            <section
+              key={part.id}
+              className={
+                partIndex > 0
+                  ? "mt-[26px] border-t border-[hsl(40_15%_86%)]"
+                  : undefined
+              }
+            >
+              {part.name && (
+                <h2 className="mt-[22px] font-serif text-xl font-normal">
+                  {part.name}
+                </h2>
+              )}
+
+              {part.ingredients.length > 0 && (
+                <div className={part.name ? "mt-2.5" : "mt-0"}>
+                  {part.ingredients.map((ingredient) => {
+                    const amount = [
+                      ingredient.amount === null
+                        ? ""
+                        : formatAmount(ingredient.amount),
+                      ingredient.unit ?? "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ");
+
+                    return (
+                      <div
+                        key={ingredient.id}
+                        className="grid grid-cols-[74px_1fr] gap-2.5 py-0.5 text-base leading-[1.3]"
+                      >
+                        <span className="font-bold">{amount}</span>
+                        <span className="font-medium">
+                          {ingredient.name}
+                          {ingredient.note && (
+                            <span className="text-muted-foreground font-normal">
+                              {" "}
+                              — {ingredient.note}
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {part.steps.length > 0 && (
+                <ol className="mt-3 space-y-[5px]">
+                  {part.steps.map((step, stepIndex) => (
+                    <li
+                      key={step.id}
+                      className="grid grid-cols-[22px_1fr] gap-2 text-base leading-[1.35]"
+                    >
+                      <span className="font-serif text-[hsl(18_75%_50%)]">
+                        {stepIndex + 1}
+                      </span>
+                      <span className="font-medium">{step.text}</span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-8">
+          <Button type="button" onClick={onEdit}>
+            Add recipe
+          </Button>
+        </div>
+      )}
+
+      {dinner.notes && (
+        <section className="mt-[26px] border-t border-[hsl(40_15%_86%)]">
+          <h2 className="mb-1.5 mt-5 font-serif text-base font-normal">Tips</h2>
+          <p className="whitespace-pre-wrap text-[15px] font-medium leading-[1.5] text-[hsl(24_10%_25%)]">
+            {dinner.notes}
+          </p>
+        </section>
+      )}
+    </article>
+  );
+};

--- a/apps/web/src/views/Dinners/RecipeView.tsx
+++ b/apps/web/src/views/Dinners/RecipeView.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from "react";
 import { ExternalLink } from "lucide-react";
 import { formatAmount, type DinnerWithRecipe } from "@planeatrepeat/shared";
+import { cn } from "../../lib/utils";
 import { Button } from "../../components/ui/button";
 
 type Props = {
@@ -15,6 +16,11 @@ const sourceLabel = (link: string) => {
     return link;
   }
 };
+
+const hasAmounts = (part: DinnerWithRecipe["parts"][number]) =>
+  part.ingredients.some(
+    (ingredient) => ingredient.amount !== null || ingredient.unit !== null,
+  );
 
 export const RecipeView = ({ dinner, onEdit }: Props) => {
   const hasRecipe = dinner.parts.length > 0;
@@ -92,11 +98,16 @@ export const RecipeView = ({ dinner, onEdit }: Props) => {
 
               {part.ingredients.length > 0 && (
                 // max-content sizes the amount column to the part's longest
-                // amount, and collapses it when no ingredient has one.
+                // amount; the column (and its gap) is dropped entirely when
+                // no ingredient in the part has one.
                 <div
-                  className={`grid grid-cols-[max-content_1fr] gap-x-2.5 gap-y-1 text-base leading-[1.3] ${
-                    part.name ? "mt-2.5" : "mt-0"
-                  }`}
+                  className={cn(
+                    "grid gap-y-1 text-base leading-[1.3]",
+                    hasAmounts(part)
+                      ? "grid-cols-[max-content_1fr] gap-x-2.5"
+                      : "grid-cols-1",
+                    part.name ? "mt-2.5" : "mt-0",
+                  )}
                 >
                   {part.ingredients.map((ingredient) => {
                     const amount = [
@@ -110,7 +121,9 @@ export const RecipeView = ({ dinner, onEdit }: Props) => {
 
                     return (
                       <Fragment key={ingredient.id}>
-                        <span className="font-bold">{amount}</span>
+                        {hasAmounts(part) && (
+                          <span className="font-bold">{amount}</span>
+                        )}
                         <span className="font-medium">
                           {ingredient.name}
                           {ingredient.note && (

--- a/apps/web/src/views/Plan/PlannedDinner.tsx
+++ b/apps/web/src/views/Plan/PlannedDinner.tsx
@@ -87,7 +87,7 @@ export const PlannedDinner = ({
           </Button>
           <ClearDay date={date} closeDialog={closeDialog} />
           <Button variant={"outline"} asChild>
-            <Link href={`/dinners/${dinner.id}`}>Edit dinner</Link>
+            <Link href={`/dinners/${dinner.id}`}>View dinner</Link>
           </Button>
         </div>
       </div>

--- a/packages/db/prisma/seed.data.ts
+++ b/packages/db/prisma/seed.data.ts
@@ -95,7 +95,7 @@ export const dinners: DinnerSeed[] = [
           ingredients: [
             { name: "spaghetti", amount: 400, unit: "g", note: null },
             { name: "pancetta", amount: 150, unit: "g", note: "diced" },
-            { name: "eggs", amount: 4, unit: "stk", note: null },
+            { name: "eggs", amount: 4, unit: "pcs", note: null },
             { name: "pecorino", amount: 100, unit: "g", note: "finely grated" },
             {
               name: "black pepper",
@@ -149,8 +149,8 @@ export const dinners: DinnerSeed[] = [
               unit: "g",
               note: "cut into pieces",
             },
-            { name: "yoghurt", amount: 2, unit: "ss", note: null },
-            { name: "curry powder", amount: 2, unit: "ts", note: null },
+            { name: "yoghurt", amount: 2, unit: "tbsp", note: null },
+            { name: "curry powder", amount: 2, unit: "tsp", note: null },
           ],
           steps: [
             "Mix the chicken with yoghurt and curry powder.",
@@ -160,9 +160,9 @@ export const dinners: DinnerSeed[] = [
         {
           name: "Sauce",
           ingredients: [
-            { name: "onion", amount: 1, unit: "stk", note: "finely chopped" },
-            { name: "garlic", amount: 3, unit: "stk", note: "minced" },
-            { name: "ginger", amount: 1, unit: "ss", note: "grated" },
+            { name: "onion", amount: 1, unit: "pcs", note: "finely chopped" },
+            { name: "garlic", amount: 3, unit: "pcs", note: "minced" },
+            { name: "ginger", amount: 1, unit: "tbsp", note: "grated" },
             { name: "coconut milk", amount: 400, unit: "ml", note: null },
           ],
           steps: [

--- a/packages/shared/src/recipe.ts
+++ b/packages/shared/src/recipe.ts
@@ -22,3 +22,5 @@ export const recipeSchema = z.object({
 });
 
 export type RecipeInput = z.infer<typeof recipeSchema>;
+
+export const formatAmount = (amount: number) => String(amount);

--- a/packages/shared/src/recipe.ts
+++ b/packages/shared/src/recipe.ts
@@ -24,3 +24,21 @@ export const recipeSchema = z.object({
 export type RecipeInput = z.infer<typeof recipeSchema>;
 
 export const formatAmount = (amount: number) => String(amount);
+
+// Editors keep amounts as text so partial input like "1," or "0.5" survives
+// re-renders and comma decimals work; parseAmount converts back on save.
+export const parseAmount = (value: string) => {
+  const normalized = value.trim().replace(",", ".");
+  if (normalized === "") return null;
+  const parsed = Number(normalized);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const amountInputSchema = z
+  .string()
+  .trim()
+  .refine((value) => {
+    if (value === "") return true;
+    const parsed = Number(value.replace(",", "."));
+    return !Number.isNaN(parsed) && parsed > 0;
+  }, "Amount must be a number more than 0");

--- a/packages/shared/src/recipe.ts
+++ b/packages/shared/src/recipe.ts
@@ -1,6 +1,15 @@
 import { z } from "zod";
 
-export const UNITS = ["g", "kg", "ml", "dl", "l", "ss", "ts", "stk"] as const;
+export const UNITS = [
+  "g",
+  "kg",
+  "ml",
+  "dl",
+  "l",
+  "tbsp",
+  "tsp",
+  "pcs",
+] as const;
 export type Unit = (typeof UNITS)[number];
 
 export const recipeIngredientSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@react-navigation/bottom-tabs':
         specifier: ^7.3.9
         version: 7.12.0(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.0)(react-native-screens@4.16.0)(react-native@0.81.5)(react@19.1.0)
+      '@react-navigation/elements':
+        specifier: ^2.9.5
+        version: 2.9.5(@react-navigation/native@7.1.28)(react-native-safe-area-context@5.6.0)(react-native@0.81.5)(react@19.1.0)
       '@react-navigation/native':
         specifier: ^7.1.17
         version: 7.1.28(react-native@0.81.5)(react@19.1.0)


### PR DESCRIPTION
## Summary

- replace the dinner edit dialog with a real `/dinners/[dinnerId]` detail screen
- add the high-fidelity, read-optimized recipe view from the design handoff
- add the mobile-first recipe editor with focused ingredient/step rows, nested add/remove/reorder controls, autocomplete, and full dinner editing
- preserve lightweight dinner creation and navigate new dinners to their detail page
- move delete confirmation into the detail editor, including affected plan dates

## Why

Issue #91 introduces the web surface for the structured recipe model from #90. The detail page is now the single place to view and edit a dinner, while the simple one-part recipe case keeps the parts concept invisible.

This is a stacked PR based on `codex/issue-90-recipe-api` / #99.

Closes #91

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- browser-tested at 375×812 for multi-part, single unnamed part, and no-recipe states
- exercised ingredient focused-row expansion, first-part creation, and a save/refetch round trip