### PR TITLE
Use relative PostHog api_host so ingest works on any origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ generated
 
 # local capture screenshots/artifacts
 /capture/
+
+# claude code local config
+.claude/

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -32,10 +32,8 @@ if (
   !window.navigator.webdriver
 ) {
   posthog.init(env.NEXT_PUBLIC_POSTHOG_API_KEY, {
-    api_host:
-      process.env.NODE_ENV === "development"
-        ? "http://localhost:3000/ingest"
-        : "https://www.planeatrepeat.com/ingest",
+    // Relative so it works on any dev port and on the LAN address phones use
+    api_host: "/ingest",
     loaded: (posthog) => {
       if (process.env.NODE_ENV === "development") posthog.debug();
     },


### PR DESCRIPTION
## Summary
- Replace the hardcoded PostHog `api_host` (localhost:3000 in dev, absolute prod URL) with a relative `/ingest` path. The rewrite in `next.config.mjs` proxies it on every origin, so capture now works when the dev server falls back to another port or is accessed via LAN IP from a phone, and prod behavior is unchanged.
- Gitignore `.claude/` local session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)