### PR TITLE
[codex] Align dinner name validation

### DIFF
--- a/apps/mobile/src/components/dinners/RecipeEditor.tsx
+++ b/apps/mobile/src/components/dinners/RecipeEditor.tsx
@@ -39,6 +39,7 @@ import {
   UNITS,
   type DinnerWithRecipe,
   amountInputSchema,
+  dinnerNameSchema,
   recipeIngredientSchema,
 } from "@planeatrepeat/shared";
 import { api } from "../../utils/api";
@@ -55,7 +56,7 @@ const editorIngredientSchema = recipeIngredientSchema.extend({
 });
 
 const recipeEditorSchema = z.object({
-  name: z.string().trim().min(1, "Add a dinner name"),
+  name: dinnerNameSchema,
   tags: z.array(z.string()),
   newTag: z.string().optional(),
   link: z.union([z.literal(""), z.string().url("Enter a valid URL")]),

--- a/apps/web/src/server/api/routers/dinner.ts
+++ b/apps/web/src/server/api/routers/dinner.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  dinnerNameSchema,
   recipeSchema,
   type DinnerWithRecipe,
   type RecipeInput,
@@ -118,7 +119,7 @@ export const dinnerRouter = createTRPCRouter({
   create: protectedProcedureWithHousehold
     .input(
       z.object({
-        dinnerName: z.string().min(3),
+        dinnerName: dinnerNameSchema,
         tagList: z.array(z.string()),
         link: z.string().nullable().optional(),
         notes: z.string().nullable().optional(),
@@ -160,7 +161,7 @@ export const dinnerRouter = createTRPCRouter({
   edit: protectedProcedureWithHousehold
     .input(
       z.object({
-        dinnerName: z.string().min(3),
+        dinnerName: dinnerNameSchema,
         dinnerId: z.number(),
         tagList: z.array(z.string()),
         link: z.string().nullable().optional(),

--- a/apps/web/src/views/Dinners/RecipeEditor.tsx
+++ b/apps/web/src/views/Dinners/RecipeEditor.tsx
@@ -21,6 +21,7 @@ import {
   UNITS,
   type DinnerWithRecipe,
   amountInputSchema,
+  dinnerNameSchema,
   recipeIngredientSchema,
 } from "@planeatrepeat/shared";
 import { api } from "../../utils/api";
@@ -41,7 +42,7 @@ const editorIngredientSchema = recipeIngredientSchema.extend({
 });
 
 const recipeEditorSchema = z.object({
-  name: z.string().trim().min(1, "Add a dinner name"),
+  name: dinnerNameSchema,
   tags: z.array(z.string()),
   newTag: z.string().optional(),
   link: z.union([z.literal(""), z.string().url("Enter a valid URL")]),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -18,8 +18,13 @@ export type DinnerWithRecipe = DinnerWithTags & {
   >;
 };
 
+export const dinnerNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Add a dinner name");
+
 export const dinnerFormSchema = z.object({
-  name: z.string().min(1),
+  name: dinnerNameSchema,
   tags: z.array(z.string()),
   newTag: asOptionalStringWithoutEmpty(z.string().max(20).min(1)),
   link: asOptionalStringWithoutEmpty(z.string().url()),


### PR DESCRIPTION
## Summary

- define a shared dinner-name schema with a one-character minimum and friendly validation message
- reuse that schema in the web and mobile recipe editors
- apply the same schema to the server create and edit procedures

## Why

Client forms accepted one- and two-character dinner names while the server required at least three characters. This caused valid-looking submissions to fail after reaching the server. Centralizing the rule keeps every client and the API aligned, and trimming prevents whitespace-only names.

## Impact

Users can create or rename dinners with any non-empty name, including one- and two-character names, without an unexpected server rejection.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

Closes #101