### PR TITLE
Cap pg pool size to fix session-mode connection exhaustion

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10,8 +10,25 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
+// With the pg driver adapter, `pg.Pool` (not Prisma) owns connection pooling,
+// and the `connection_limit` URL param is ignored. Each warm serverless
+// instance would otherwise open up to pg's default of 10 connections; a few
+// concurrent instances then blow past Supabase's session-mode pooler limit
+// (pool_size 15) and throw EMAXCONNSESSION. Cap the pool low and release idle
+// sessions quickly so instances share the pooler budget.
+const POOL_MAX = Number(process.env.DATABASE_POOL_MAX ?? 3);
+const POOL_IDLE_TIMEOUT_MS = 10_000;
+
+function createPool(connectionString: string) {
+  return new Pool({
+    connectionString,
+    max: POOL_MAX,
+    idleTimeoutMillis: POOL_IDLE_TIMEOUT_MS,
+  });
+}
+
 export function createPrismaClient(connectionString: string) {
-  const pool = new Pool({ connectionString });
+  const pool = createPool(connectionString);
   const adapter = new PrismaPg(pool);
   return new PrismaClient({ adapter });
 }
@@ -21,7 +38,7 @@ export function getDb(connectionString: string, isDev = false) {
     return globalForPrisma.prisma;
   }
 
-  const pool = new Pool({ connectionString });
+  const pool = createPool(connectionString);
   const adapter = new PrismaPg(pool);
 
   const db = new PrismaClient({


### PR DESCRIPTION
## Problem

Production was throwing a red toast on normal navigation (planning dinners, editing a dinner name, browser-back):

> `(EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15`

## Root cause

The `@prisma/adapter-pg` migration (`9324b55`) handed connection pooling from Prisma to a raw `pg.Pool`. Unlike Prisma's built-in pool, `pg.Pool` **ignores the `connection_limit` URL parameter** and defaults to `max: 10` connections per instance. A couple of concurrent warm serverless instances then exceed Supabase's **session-mode** pooler limit (`pool_size: 15`).

The `connection_limit` value we'd historically relied on (per Supabase's Prisma docs) silently stopped applying once pooling moved to the driver.

## Fix

Cap the `pg.Pool` (`DATABASE_POOL_MAX`, default `3`) and set a short idle timeout so warm instances release sessions and share the pooler budget. This restores the per-instance connection limit in the place the driver adapter moved it to.

## Scope / notes

- Runtime stays on the **session-mode** pooler — no `DATABASE_URL`/`DIRECT_URL` changes, so the existing `prisma migrate deploy` step in `vercel-build` is untouched and keeps working.
- Migrating runtime to the transaction pooler (6543) would be more robust long-term but requires splitting the runtime vs. migration connection strings; deliberately deferred.
- Tune `DATABASE_POOL_MAX` if concurrency grows: keep `instances × max ≤ 15` while on session mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)