### PR TITLE
Fix CommandEmpty dropping caller-supplied className

### DIFF
--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -70,10 +70,10 @@ CommandList.displayName = CommandPrimitive.List.displayName
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
+>(({ className, ...props }, ref) => (
   <CommandPrimitive.Empty
     ref={ref}
-    className="py-6 text-center text-sm"
+    className={cn("py-6 text-center text-sm", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## What changed

`CommandEmpty` in `apps/web/src/components/ui/command.tsx` set `className` *before* spreading `{...props}`:

```tsx
<CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
```

Because the spread comes last, a caller-supplied `className` silently overwrote the base styles rather than merging — `<CommandEmpty className="text-muted-foreground">` would have lost the padding, centering, and text size.

Now it destructures `className` and merges via `cn()`, matching the pattern every other component in the file already uses (`Command`, `CommandInput`, `CommandList`, `CommandGroup`, `CommandSeparator`, `CommandItem`, `CommandShortcut`).

## Why

Genuine defect in app source — found while building design-system preview cards, not a preview artifact. `CommandEmpty` was the only component in this file that broke the convention, which makes it a quiet trap: the override is invisible at the call site and only shows up as missing styling.

## For reviewers

**This is behaviour-preserving as of today.** `CommandEmpty` currently has **zero callers** — the only occurrences of the symbol in the repo are its own definition and its export. `FancyCombobox.tsx` imports only `Command`, `CommandList`, `CommandGroup`, and `CommandItem`, and the other cmdk consumer (`views/Dinners/RecipeEditor.tsx`) goes through `FancyCombobox`. So nothing was relying on the override, and nothing renders differently after this change; it only fixes the trap for future use.

## Verification

- `pnpm --filter @planeatrepeat/web typecheck` — clean
- `pnpm --filter @planeatrepeat/web lint` — no ESLint warnings or errors

Two environment notes, unrelated to this change and not addressed here: `next lint` loads `next.config.mjs`, which runs T3 env validation, so it needs `SKIP_ENV_VALIDATION=1` in a checkout without a `.env`. Locally, Node v24.11.1 is below the declared `>=24.12.0` engine requirement; it didn't affect either check.

No browser verification — with no callers, the component renders nowhere in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)