### PR TITLE
Add design-sync inputs for claude.ai/design import

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,193 @@
+# design-sync notes — PlanEatRepeat
+
+Repo-specific gotchas for syncing this design system to claude.ai/design.
+Read this before re-running the sync.
+
+## What the "design system" is here
+
+There is no separate design-system package and no Storybook. The synced surface
+is `apps/web/src/components/ui/` — the shadcn/ui component set the web app is
+built from (108 exported components), styled by Tailwind 3.4 with the
+"Warm Stone" CSS-variable theme in `apps/web/src/styles/globals.css`.
+
+`apps/web/src/components/*.tsx` (AppLayout, AppSidebar, Modal, ResponsiveModal)
+are deliberately **out of scope**: they import Clerk, tRPC and `next/router`, so
+they cannot render in a preview and are app shell rather than design system.
+That exclusion is enforced by `cfg.srcDir = "src/components/ui"`.
+
+## Per-clone setup (not committed, must be recreated)
+
+- **The package self-link.** The converter resolves the package as
+  `join(<node-modules>, <pkg>)`, but pnpm does not self-link a workspace app.
+  Recreate it before building:
+  ```sh
+  mkdir -p node_modules/@planeatrepeat && ln -sfn ../../apps/web node_modules/@planeatrepeat/web
+  ```
+  Without it the build fails to find the package directory.
+- **`--node-modules` must be the repo root, not `apps/web/node_modules`.** The
+  repo sets `node-linker=hoisted` in `.npmrc`, so `react` and everything else
+  lives at the root; `apps/web/node_modules` holds only three scoped dirs.
+- **Restage the converter scripts** (`.ds-sync/`) and reinstall its deps —
+  both are gitignored.
+
+## Why some inputs live under `apps/web/` instead of `.design-sync/`
+
+`cfg.cssEntry` is bounded to the package directory by the converter, and
+package-relative paths resolve through the self-link (so `../..` lands inside
+`node_modules`, not the repo root). Two design-sync inputs therefore live
+inside the package:
+
+- `apps/web/design-sync-styles/` — the Tailwind build that produces the
+  shipped stylesheet.
+- `apps/web/design-sync-docs/` — one `.md` per component. These set the
+  component grouping (via `category:` frontmatter) and become each component's
+  `.prompt.md`, which is what the design agent reads.
+
+Both are committed. `.design-sync/` still holds config, notes, conventions and
+the authored previews.
+
+## The stylesheet is generated, and must be rebuilt before the converter
+
+`cfg.buildCmd` is `sh apps/web/design-sync-styles/build.sh`. It regenerates
+`candidates.txt` and compiles `ds.css` (~1.2 MB minified, gitignored).
+
+The subtlety worth understanding: a Next.js app has no compiled stylesheet on
+disk, and Tailwind only emits utilities it can see in `content`. Designs the
+Claude Design agent writes later are not in `content` at build time, so
+`gen-candidates.mjs` synthesises a corpus of ~18k plausible utility class names
+(layout, spacing, sizing, typography, the semantic colour palette, states and
+breakpoints) purely so those utilities exist in the shipped CSS. Widen that
+generator rather than hand-editing `ds.css`.
+
+**Rebuild the stylesheet whenever an authored preview uses a new utility** —
+`.design-sync/previews/**/*.tsx` is in the Tailwind `content` globs, but only
+the full `build.sh` re-reads it. Subagents authoring previews cannot run it
+(it is a shared-artifact command), so give every preview batch this house rule:
+
+> **Named scale values only — no arbitrary values in square brackets.**
+> `w-[380px]` compiles to nothing and fails silently. A bracket class only
+> works if that exact string already appears somewhere in `apps/web/**` (which
+> is why `min-h-[100px]` survives — `views/Dinners/DinnerList.tsx` uses it).
+
+The same constraint applies to designs built in claude.ai/design, and is
+documented for the design agent in `conventions.md`.
+
+## Toast: the imperative API needs `extraEntries`
+
+`toast()` and `useToast` live in `src/components/ui/use-toast.ts`, a `.ts` file.
+The synth entry only re-exports `.tsx`/`.jsx`, so they were initially missing
+from the bundle. Fixed by
+`"extraEntries": ["./src/components/ui/use-toast.ts"]` — keep that entry, or the
+design agent gets `Toaster` with no way to drive it.
+
+The `Toaster` preview still reproduces the markup `Toaster` emits rather than
+firing a real `toast()`, because it was authored before the export landed. A
+future sync could improve it: fire one from a `useEffect` now that `toast` is
+importable.
+
+## Fonts
+
+Quicksand and Young Serif are loaded by a remote `@import` from Google Fonts in
+`design-sync-styles/input.css`, and `--font-quicksand` / `--font-young-serif`
+are bound to them in `:root`. In the app itself these variables come from
+`next/font/google` at runtime; the design system cannot rely on that, hence the
+CDN import. Validate reports `[FONT_REMOTE]` for this — expected, not a defect.
+
+If the fonts ever need to be self-hosted, `next/font` caches the woff2 files in
+`apps/web/.next/static/media/` under content-hashed names, but nothing on disk
+maps a hash back to a family — identify them before shipping any of them.
+
+## Authoring previews — techniques that work here
+
+Folded in from the four authoring batches. Each of these cost a debugging cycle.
+
+- **Portalling overlays** (`Dialog`, `Sheet`, `Drawer`): set `open` on the root
+  AND keep the `*Trigger` in the tree. The panel portals to `document.body`, so
+  without the trigger the card root is empty and the render check fails; the
+  trigger ends up under the dim overlay, which is fine.
+- **`CommandDialog` exports no trigger.** Wrap it in a `div` beside a plain
+  `Button` styled as the ⌘K affordance. Reuse this shape for any portalling
+  component with no trigger export.
+- **`Drawer` needs `shouldScaleBackground={false}`.** Vaul's default expects a
+  `[vaul-drawer-wrapper]` ancestor the preview harness does not provide.
+- **`Tooltip`** needs a `TooltipProvider` inside the preview file — not a
+  harness-level `cfg.provider`.
+- **Every `Sidebar*` part** needs `SidebarProvider` → `Sidebar` with
+  `collapsible="none"`. The default branches are `position: fixed` +
+  `hidden md:block`, so nothing renders in flow. Constrain the panel's box with
+  an inline `style` prop, not Tailwind: `twMerge` does not recognise
+  `min-h-svh`, keeps it alongside `min-h-0`, and `min-height` then beats any
+  `height` class — so no class can size `SidebarProvider`.
+- **`Toast`** needs both `ToastProvider` and `ToastViewport` in the tree, plus
+  `duration={Infinity}` or it auto-dismisses before the screenshot. Override
+  only `static flex-col p-0` on the viewport so the app's real width cap shows.
+- **`AvatarImage` never loads** in the capture sandbox — every Avatar cell falls
+  through to `AvatarFallback`. Write the initials to read well; that is the
+  honest app state anyway.
+- **`Separator orientation="vertical"`** is `h-full w-[1px]` and collapses
+  without a height on itself or the flex row.
+- **`Label`'s `peer-disabled:` dimming** only reaches a label that follows its
+  peer in the DOM; `flex-col-reverse` is how to demonstrate it honestly.
+- **`SelectContent` inherits the trigger's width**, so keep the trigger at a
+  scale width or the panel overflows the card.
+- **`FancyCombobox` has no `open` prop** — the menu follows the input's focus
+  state, so an open story focuses the input from a `useEffect`. Its list is
+  capped at `max-h-[35dvh]`; keep the selectable set to 4 on a 560x420 card.
+- Card sub-parts, Sidebar parts and Select parts render nothing standalone —
+  their honest preview is the full parent composition, framed so the subject
+  part is what the eye lands on.
+
+## Orchestration: do not edit config during a fan-out
+
+`preview-rebuild.mjs` hard-exits with `[CONFIG_STALE]` when
+`.design-sync/config.json` changes after the stamped build, and there is no
+bypass flag. Editing config mid-wave therefore breaks **every** scoped agent at
+once — it cost this run one batch's grading pass. Batch config edits before a
+wave starts or after it folds, never during.
+
+(Also: a wait-loop using `pgrep -f "preview-rebuild.mjs"` matches its own shell
+and never exits. Wait on a PID.)
+
+## Card modes (presentation, set from `[GRID_OVERFLOW]`)
+
+`cfg.overrides` pins how six components present in the product's card grid:
+`Toast`/`Toaster` are `single` (their viewport is fixed/portalled, so no grid
+layout can hold them), and `Command`/`CardContent`/`CardFooter`/`CardHeader` are
+`column` (their stories are wider than a grid cell). The seven overlay
+components are `single` with explicit viewports. These are presentation-only —
+grades carry across changes to them.
+
+## Found in passing, not fixed
+
+`CommandEmpty` in `src/components/ui/command.tsx` sets `className` *before*
+spreading `{...props}`, so a caller-supplied `className` replaces its base
+styles instead of merging through `cn` — unlike every other component in that
+file. Worked around in the preview by not passing a className.
+
+## Known render warns (triaged, not new)
+
+- `[FONT_REMOTE] "Quicksand", "Young Serif"` — by design, see above.
+- `tokens: 1 missing` — below the converter's threshold; the referenced
+  custom property is defined at runtime, not in the stylesheet.
+- Components left on the floor card are structural sub-parts (portals,
+  overlays, scroll buttons) that render nothing standalone. That is the
+  documented baseline, not a failure.
+
+## Re-sync risks
+
+- **The self-link and `.ds-sync/` are recreated per clone** (above). A re-sync on
+  a fresh machine that skips them fails at the first build.
+- **`ds.css` is gitignored and generated.** A re-sync that does not run
+  `buildCmd` first will either fail (`cssEntry` not found) or, worse, ship a
+  stale stylesheet missing utilities that newer previews use.
+- **The candidate corpus is a guess, not a contract.** If designs built in
+  claude.ai/design come out partly unstyled, the cause is almost certainly a
+  utility family missing from `gen-candidates.mjs` — check the rendered design's
+  class names against `ds.css` before suspecting anything else.
+- **Component docs are hand-written.** Adding a component to
+  `src/components/ui/` without adding `apps/web/design-sync-docs/<Name>.md`
+  drops it into a `misc` group and gives it a synthesised prompt instead of a
+  real one. The converter prints `[DOCS_UNMAPPED]` when this happens.
+- **Google Fonts is a runtime dependency of every rendered design.** If the
+  design environment blocks external hosts, everything falls back to system
+  fonts and nothing in the pipeline will flag it.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,65 @@
+{
+  "projectId": "d901d8ce-3c98-4c10-a14d-11f441b80480",
+  "shape": "package",
+  "pkg": "@planeatrepeat/web",
+  "globalName": "PlanEatRepeat",
+  "srcDir": "src/components/ui",
+  "tsconfig": "tsconfig.json",
+  "cssEntry": "design-sync-styles/ds.css",
+  "docsDir": "design-sync-docs",
+  "buildCmd": "sh apps/web/design-sync-styles/build.sh",
+  "overrides": {
+    "Dialog": {
+      "cardMode": "single",
+      "viewport": "720x520"
+    },
+    "Sheet": {
+      "cardMode": "single",
+      "viewport": "760x520"
+    },
+    "Drawer": {
+      "cardMode": "single",
+      "viewport": "640x620"
+    },
+    "Tooltip": {
+      "cardMode": "single",
+      "viewport": "520x300"
+    },
+    "CommandDialog": {
+      "cardMode": "single",
+      "viewport": "720x520"
+    },
+    "Select": {
+      "cardMode": "single",
+      "viewport": "520x420"
+    },
+    "FancyCombobox": {
+      "cardMode": "single",
+      "viewport": "560x420"
+    },
+    "Toast": {
+      "cardMode": "single",
+      "primaryStory": "Saved"
+    },
+    "Toaster": {
+      "cardMode": "single",
+      "primaryStory": "StackedToasts"
+    },
+    "Command": {
+      "cardMode": "column"
+    },
+    "CardContent": {
+      "cardMode": "column"
+    },
+    "CardFooter": {
+      "cardMode": "column"
+    },
+    "CardHeader": {
+      "cardMode": "column"
+    }
+  },
+  "readmeHeader": ".design-sync/conventions.md",
+  "extraEntries": [
+    "./src/components/ui/use-toast.ts"
+  ]
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,93 @@
+# Building with the PlanEatRepeat design system
+
+A warm, domestic UI for a dinner-planning app. Terracotta primary on warm
+off-white ("Warm Stone"), generous 0.75rem corners, Quicksand for text and
+Young Serif for display headings.
+
+## Setup
+
+No root provider is needed for styling. `styles.css` defines every theme token
+on `:root`, so components are correctly styled as soon as it is loaded. Three
+components do require a wrapper, and render blank or throw without it:
+
+- **`SidebarProvider`** — required ancestor of every `Sidebar*` component.
+- **`TooltipProvider`** — required ancestor of every `Tooltip*` component. Mount
+  one high in the tree, not one per tooltip.
+- **`Toaster`** — mount once near the root; `toast({ title, description })` then
+  renders through it. Do not render `Toast` directly in app code.
+
+Dark mode is class-based: put `class="dark"` on an ancestor (usually `<html>`).
+
+## Styling: Tailwind utilities, semantic tokens only
+
+Style with Tailwind utility classes. **Always reach for the semantic token
+names below rather than raw palette colours** (`bg-stone-100`, `text-red-500`)
+— the semantic names are what carry the brand and what dark mode re-maps. Raw
+palettes exist in the stylesheet as an escape hatch, but a design built from
+them is off-brand and will not invert correctly.
+
+| Family | Names |
+|---|---|
+| Page | `bg-background` `text-foreground` |
+| Surfaces | `bg-card` `text-card-foreground` `bg-popover` `text-popover-foreground` |
+| Brand | `bg-primary` `text-primary-foreground` (terracotta) |
+| Quiet fills | `bg-secondary` `text-secondary-foreground` `bg-muted` `text-muted-foreground` |
+| Hover / highlight | `bg-accent` `text-accent-foreground` |
+| Danger | `bg-destructive` `text-destructive-foreground` |
+| Lines & focus | `border-border` `border-input` `ring-ring` |
+| Sidebar (warmer, use inside `Sidebar` only) | `bg-sidebar` `text-sidebar-foreground` `bg-sidebar-accent` `text-sidebar-accent-foreground` `border-sidebar-border` `bg-sidebar-primary` |
+
+All of these take opacity modifiers — `hover:bg-accent/50`, `border-primary/50`
+— which is how the app builds its hover states.
+
+Radius: `rounded-lg` is the brand radius (0.75rem); `rounded-md` and
+`rounded-sm` step down from it. Type: `font-sans` (Quicksand) is the default;
+`font-serif` (Young Serif) is for display — dinner names, card titles, page
+headings. Everything else is stock Tailwind v3 (`flex`, `grid`, `gap-*`,
+`p-*`, `space-y-*`, `text-sm`, `sm:`/`md:`/`lg:`, `hover:`, `focus-visible:`).
+
+**Arbitrary values in square brackets do not work.** The stylesheet is
+pre-compiled and shipped, so there is no build step to generate a class like
+`w-[380px]` or `text-[13px]` on demand — it produces no CSS at all and fails
+silently, leaving the element unstyled in that dimension. Use the named scale
+(`w-96`, `text-sm`), or, when you genuinely need an exact one-off value, an
+inline `style={{ width: 380 }}`, which needs no stylesheet support.
+
+## Where the truth lives
+
+Read `_ds/<folder>/styles.css` and the files it `@import`s — that is the real,
+complete utility and token surface, and it beats any summary here. Per
+component, `<Name>.prompt.md` has a hand-written description and a worked
+example, and `<Name>.d.ts` has the exact props.
+
+## Idiomatic example
+
+Library components for the controls; Tailwind utilities for your own layout glue.
+
+```jsx
+<div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+  {dinners.map((dinner) => (
+    <Card
+      key={dinner.id}
+      className="hover:bg-accent/50 flex h-full min-h-[100px] cursor-pointer flex-col justify-between transition-colors"
+    >
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="line-clamp-2 font-serif text-base font-medium leading-tight sm:text-lg">
+          {dinner.name}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-4 pt-2">
+        <div className="flex flex-wrap gap-1">
+          {dinner.tags.map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-xs">{tag}</Badge>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  ))}
+</div>
+```
+
+Note the two habits worth copying: `Card`'s default padding is generous, so
+dense grids tighten it with `p-4 pb-2`; and interactive cards get
+`hover:bg-accent/50 cursor-pointer transition-colors` rather than a new variant.

--- a/.design-sync/previews/Avatar.tsx
+++ b/.design-sync/previews/Avatar.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@planeatrepeat/web";
+
+export const MemberRow = () => (
+  <div className="flex items-center space-x-4">
+    <Avatar>
+      <AvatarImage src="/avatars/aslak.png" alt="Aslak Hollund" />
+      <AvatarFallback>AH</AvatarFallback>
+    </Avatar>
+    <div>
+      <h3 className="font-serif text-lg font-semibold leading-tight">
+        Aslak Hollund
+      </h3>
+      <p className="text-muted-foreground text-sm">Admin</p>
+    </div>
+  </div>
+);
+
+export const HouseholdMembers = () => (
+  <Card className="w-80">
+    <CardHeader>
+      <CardTitle className="font-serif text-xl">Members</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <ul className="space-y-4">
+        {[
+          { name: "Aslak Hollund", initials: "AH", role: "Admin" },
+          { name: "Marte Nilsen", initials: "MN", role: "Member" },
+          { name: "Jonas Berg", initials: "JB", role: "Member" },
+        ].map((member) => (
+          <li key={member.name} className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Avatar className="h-8 w-8">
+                <AvatarImage src={`/avatars/${member.initials}.png`} alt="" />
+                <AvatarFallback className="text-xs font-semibold">
+                  {member.initials}
+                </AvatarFallback>
+              </Avatar>
+              <span className="text-sm">{member.name}</span>
+            </div>
+            <span className="text-muted-foreground text-xs">{member.role}</span>
+          </li>
+        ))}
+      </ul>
+    </CardContent>
+  </Card>
+);
+
+export const CookingTonight = () => (
+  <div className="flex items-center gap-3">
+    <div className="flex -space-x-2">
+      {["AH", "MN", "JB", "SL"].map((initials) => (
+        <Avatar key={initials} className="border-background h-8 w-8 border-2">
+          <AvatarImage src={`/avatars/${initials}.png`} alt="" />
+          <AvatarFallback className="bg-primary text-primary-foreground text-xs font-semibold">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+      ))}
+    </div>
+    <span className="text-muted-foreground text-sm">
+      4 eating Thursday&apos;s fish tacos
+    </span>
+  </div>
+);

--- a/.design-sync/previews/Badge.tsx
+++ b/.design-sync/previews/Badge.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@planeatrepeat/web";
+
+export const Variants = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Badge>Family favourite</Badge>
+    <Badge variant="secondary">Vegetarian</Badge>
+    <Badge variant="outline">20 min</Badge>
+    <Badge variant="destructive">Missing recipe</Badge>
+  </div>
+);
+
+export const DinnerTags = () => (
+  <Card className="w-64">
+    <CardHeader className="p-4 pb-2">
+      <CardTitle className="font-serif text-lg font-medium leading-tight">
+        Chickpea curry with rice
+      </CardTitle>
+    </CardHeader>
+    <CardContent className="p-4 pt-2">
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="secondary">Vegetarian</Badge>
+        <Badge variant="secondary">30 min</Badge>
+        <Badge variant="secondary">Leftovers</Badge>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+export const TagFilter = () => (
+  <div className="max-w-md space-y-2">
+    <p className="text-muted-foreground text-sm">Filter dinners by tag</p>
+    <div className="flex flex-wrap gap-2">
+      <Badge variant="secondary" className="border-primary bg-primary/10 border">
+        Vegetarian
+      </Badge>
+      <Badge variant="secondary">Quick</Badge>
+      <Badge variant="secondary" className="border-primary bg-primary/10 border">
+        Family favourite
+      </Badge>
+      <Badge variant="secondary">Friday</Badge>
+      <Badge variant="secondary">Fish</Badge>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { Button } from "@planeatrepeat/web";
+import { Plus, Trash2, Loader2 } from "lucide-react";
+
+export const Variants = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <Button>Add dinner</Button>
+    <Button variant="secondary">Cancel</Button>
+    <Button variant="outline">Edit</Button>
+    <Button variant="ghost">Skip</Button>
+    <Button variant="link">Learn more</Button>
+    <Button variant="destructive">Delete</Button>
+  </div>
+);
+
+export const Sizes = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <Button size="sm">Small</Button>
+    <Button size="default">Default</Button>
+    <Button size="lg">Large</Button>
+    <Button size="icon" aria-label="Add dinner">
+      <Plus />
+    </Button>
+  </div>
+);
+
+export const WithIcons = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <Button>
+      <Plus />
+      Add dinner
+    </Button>
+    <Button variant="outline">
+      <Loader2 className="animate-spin" />
+      Importing…
+    </Button>
+    <Button variant="destructive">
+      <Trash2 />
+      Delete dinner
+    </Button>
+  </div>
+);
+
+export const Disabled = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <Button disabled>Add dinner</Button>
+    <Button variant="secondary" disabled>
+      Cancel
+    </Button>
+    <Button variant="outline" disabled>
+      Edit
+    </Button>
+  </div>
+);

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@planeatrepeat/web";
+import { Plus } from "lucide-react";
+
+export const Basic = () => (
+  <Card className="max-w-md">
+    <CardHeader>
+      <CardTitle>Create household</CardTitle>
+      <CardDescription>
+        To use PlanEatRepeat you need a household. You can invite the people you
+        cook for later.
+      </CardDescription>
+    </CardHeader>
+    <CardContent className="text-muted-foreground text-sm">
+      A household shares its dinners and its weekly plan.
+    </CardContent>
+    <CardFooter className="justify-end gap-2">
+      <Button variant="secondary">Cancel</Button>
+      <Button>Create household</Button>
+    </CardFooter>
+  </Card>
+);
+
+export const DinnerGrid = () => (
+  <div className="grid max-w-2xl grid-cols-2 gap-3 sm:grid-cols-3">
+    {[
+      { name: "Tomato pasta", tags: ["Vegetarian", "20 min"] },
+      { name: "Fish tacos", tags: ["Friday"] },
+      { name: "Chicken curry with rice", tags: ["Family favourite"] },
+    ].map((dinner) => (
+      <Card
+        key={dinner.name}
+        className="hover:bg-accent/50 flex h-full min-h-[100px] cursor-pointer flex-col justify-between transition-colors"
+      >
+        <CardHeader className="p-4 pb-2">
+          <CardTitle className="line-clamp-2 font-serif text-base font-medium leading-tight sm:text-lg">
+            {dinner.name}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-4 pt-2">
+          <div className="flex flex-wrap gap-1">
+            {dinner.tags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    ))}
+  </div>
+);
+
+export const AddPlaceholder = () => (
+  <Card className="hover:border-primary/50 hover:bg-accent/50 flex h-full min-h-[120px] w-56 cursor-pointer flex-col items-center justify-center border-dashed bg-transparent transition-colors">
+    <CardContent className="text-muted-foreground hover:text-primary flex h-full flex-col items-center justify-center gap-2 p-4">
+      <Plus className="h-6 w-6" />
+      <span className="text-sm">New dinner</span>
+    </CardContent>
+  </Card>
+);

--- a/.design-sync/previews/CardContent.tsx
+++ b/.design-sync/previews/CardContent.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@planeatrepeat/web";
+
+export const NotesBody = () => (
+  <Card className="w-96">
+    <CardHeader>
+      <CardTitle className="font-serif text-xl">Tomato pasta</CardTitle>
+      <CardDescription>Notes</CardDescription>
+    </CardHeader>
+    <CardContent className="space-y-2 text-sm">
+      <p>
+        Fry the garlic gently, add two tins of tomatoes and let it reduce while
+        the pasta boils.
+      </p>
+      <p className="text-muted-foreground">
+        Double the sauce — it freezes well for a busy Tuesday.
+      </p>
+    </CardContent>
+  </Card>
+);
+
+export const TagsBody = () => (
+  <Card className="w-64">
+    <CardHeader className="p-4 pb-2">
+      <CardTitle className="line-clamp-2 font-serif text-base font-medium leading-tight">
+        Lentil soup with bread
+      </CardTitle>
+    </CardHeader>
+    <CardContent className="p-4 pt-2">
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="secondary">Vegetarian</Badge>
+        <Badge variant="secondary">25 min</Badge>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+export const ListBody = () => (
+  <Card className="w-80">
+    <CardHeader>
+      <CardTitle className="font-serif text-xl">This week</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <ul className="space-y-3 text-sm">
+        {[
+          { day: "Monday", dinner: "Tomato pasta" },
+          { day: "Tuesday", dinner: "Chicken curry" },
+          { day: "Wednesday", dinner: "Lentil soup" },
+          { day: "Thursday", dinner: "Fish tacos" },
+        ].map((entry) => (
+          <li key={entry.day} className="flex items-center justify-between">
+            <span className="text-muted-foreground">{entry.day}</span>
+            <span>{entry.dinner}</span>
+          </li>
+        ))}
+      </ul>
+    </CardContent>
+  </Card>
+);

--- a/.design-sync/previews/CardFooter.tsx
+++ b/.design-sync/previews/CardFooter.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@planeatrepeat/web";
+import { CalendarPlus } from "lucide-react";
+
+export const FormActions = () => (
+  <Card className="w-96">
+    <CardHeader>
+      <CardTitle className="font-serif text-xl">New dinner</CardTitle>
+      <CardDescription>
+        Give it a name now — you can add tags and a recipe link later.
+      </CardDescription>
+    </CardHeader>
+    <CardContent className="text-muted-foreground text-sm">
+      Baked feta pasta
+    </CardContent>
+    <CardFooter className="justify-end gap-2">
+      <Button variant="secondary">Cancel</Button>
+      <Button>Save dinner</Button>
+    </CardFooter>
+  </Card>
+);
+
+export const SingleAction = () => (
+  <Card className="w-80">
+    <CardHeader>
+      <CardTitle className="font-serif text-xl">Thursday is empty</CardTitle>
+      <CardDescription>Nothing planned for this day yet.</CardDescription>
+    </CardHeader>
+    <CardFooter>
+      <Button className="w-full">
+        <CalendarPlus className="mr-2 h-4 w-4" />
+        Plan a dinner
+      </Button>
+    </CardFooter>
+  </Card>
+);
+
+export const MetaFooter = () => (
+  <Card className="w-96">
+    <CardHeader>
+      <CardTitle className="font-serif text-xl">Fish tacos</CardTitle>
+    </CardHeader>
+    <CardContent className="text-muted-foreground text-sm">
+      Planned for Thursday 30 July.
+    </CardContent>
+    <CardFooter className="justify-between">
+      <span className="text-muted-foreground text-xs">
+        Last cooked 3 weeks ago
+      </span>
+      <Button variant="outline" size="sm">
+        Move day
+      </Button>
+    </CardFooter>
+  </Card>
+);

--- a/.design-sync/previews/CardHeader.tsx
+++ b/.design-sync/previews/CardHeader.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@planeatrepeat/web";
+import { Pencil } from "lucide-react";
+
+export const TitleAndDescription = () => (
+  <Card className="w-96">
+    <CardHeader>
+      <CardTitle className="font-serif text-2xl">Household</CardTitle>
+      <CardDescription>
+        Everyone in Hollund-Nilsen shares these dinners and this week&apos;s
+        plan.
+      </CardDescription>
+    </CardHeader>
+    <CardContent className="text-muted-foreground text-sm">
+      3 members · 48 dinners
+    </CardContent>
+  </Card>
+);
+
+export const DenseHeader = () => (
+  <Card className="flex w-56 flex-col justify-between">
+    <CardHeader className="p-4 pb-2">
+      <CardTitle className="line-clamp-2 font-serif text-base font-medium leading-tight">
+        Salmon with roasted potatoes
+      </CardTitle>
+    </CardHeader>
+    <CardContent className="p-4 pt-2">
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="secondary">Fish</Badge>
+        <Badge variant="secondary">40 min</Badge>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+export const HeaderWithAction = () => (
+  <Card className="w-96">
+    <CardHeader className="flex-row items-start justify-between space-y-0">
+      <div className="space-y-1.5">
+        <CardTitle className="font-serif text-xl">Thursday</CardTitle>
+        <CardDescription>Fish tacos with lime slaw</CardDescription>
+      </div>
+      <Button variant="ghost" size="icon">
+        <Pencil className="h-4 w-4" />
+      </Button>
+    </CardHeader>
+    <CardContent className="text-muted-foreground text-sm">
+      Planned by Marte · serves 4
+    </CardContent>
+  </Card>
+);

--- a/.design-sync/previews/Command.tsx
+++ b/.design-sync/previews/Command.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@planeatrepeat/web";
+import { CalendarDays, Plus, UtensilsCrossed } from "lucide-react";
+
+// Command is not an overlay — it renders inline. On its own it is unstyled
+// chrome, so give it a border and a width to make it read as a palette.
+export const Inline = () => (
+  <Command className="border-border w-[360px] rounded-lg border shadow-sm">
+    <CommandInput placeholder="Search dinners…" />
+    <CommandList>
+      <CommandEmpty>No dinners found.</CommandEmpty>
+      <CommandGroup heading="This week">
+        <CommandItem>
+          <CalendarDays />
+          Spaghetti carbonara
+          <CommandShortcut>Mon</CommandShortcut>
+        </CommandItem>
+        <CommandItem>
+          <CalendarDays />
+          Thai green curry
+          <CommandShortcut>Wed</CommandShortcut>
+        </CommandItem>
+      </CommandGroup>
+      <CommandSeparator />
+      <CommandGroup heading="All dinners">
+        <CommandItem>
+          <UtensilsCrossed />
+          Mushroom risotto
+        </CommandItem>
+        <CommandItem>
+          <UtensilsCrossed />
+          Veggie buddha bowl
+        </CommandItem>
+        <CommandItem>
+          <Plus />
+          New dinner
+          <CommandShortcut>⌘N</CommandShortcut>
+        </CommandItem>
+      </CommandGroup>
+    </CommandList>
+  </Command>
+);
+
+// Filtering runs off the item text, so a search with no matches falls
+// through to CommandEmpty.
+export const NoResults = () => (
+  <Command className="border-border w-[360px] rounded-lg border shadow-sm">
+    <CommandInput
+      value="sushi"
+      onValueChange={() => undefined}
+      placeholder="Search dinners…"
+    />
+    <CommandList>
+      <CommandEmpty>No dinners found.</CommandEmpty>
+      <CommandGroup heading="All dinners">
+        <CommandItem>Mushroom risotto</CommandItem>
+        <CommandItem>Fish tacos</CommandItem>
+      </CommandGroup>
+    </CommandList>
+  </Command>
+);

--- a/.design-sync/previews/CommandDialog.tsx
+++ b/.design-sync/previews/CommandDialog.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import {
+  Button,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@planeatrepeat/web";
+import { CalendarDays, Plus, Search, UtensilsCrossed } from "lucide-react";
+
+// CommandDialog is controlled only, so `open` is set to render the palette.
+// It ships no trigger of its own — the ⌘K button beside it is what keeps the
+// card root non-empty while the panel portals to document.body.
+export const Open = () => (
+  <div>
+    <Button variant="outline" className="text-muted-foreground w-56 justify-start">
+      <Search className="mr-2 h-4 w-4" />
+      Jump to…
+      <CommandShortcut>⌘K</CommandShortcut>
+    </Button>
+    <CommandDialog open>
+      <CommandInput placeholder="Jump to…" />
+      <CommandList>
+        <CommandEmpty>Nothing matches.</CommandEmpty>
+        <CommandGroup heading="Pages">
+          <CommandItem>
+            <CalendarDays />
+            This week
+          </CommandItem>
+          <CommandItem>
+            <UtensilsCrossed />
+            Dinners
+          </CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Actions">
+          <CommandItem>
+            <Plus />
+            New dinner
+          </CommandItem>
+          <CommandItem>
+            <CalendarDays />
+            Plan Tuesday
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  </div>
+);

--- a/.design-sync/previews/Dialog.tsx
+++ b/.design-sync/previews/Dialog.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Input,
+  Label,
+} from "@planeatrepeat/web";
+
+// `open` is set so the panel renders in the card. DialogContent portals to
+// document.body, so the trigger is what keeps the card root non-empty.
+export const Open = () => (
+  <Dialog open>
+    <DialogTrigger asChild>
+      <Button variant="outline">Edit dinner</Button>
+    </DialogTrigger>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Edit dinner</DialogTitle>
+        <DialogDescription>
+          Change the name, tags or notes for this dinner.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="space-y-2">
+        <Label htmlFor="dinner-name">Name</Label>
+        <Input id="dinner-name" defaultValue="Tomato pasta" />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="secondary">Cancel</Button>
+        </DialogClose>
+        <Button>Save dinner</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);

--- a/.design-sync/previews/Drawer.tsx
+++ b/.design-sync/previews/Drawer.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import {
+  Badge,
+  Button,
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@planeatrepeat/web";
+
+// `open` is set so the panel renders in the card. DrawerContent portals to
+// document.body, so the trigger is what keeps the card root non-empty.
+// DrawerContent draws its own grab handle above the header.
+export const Open = () => (
+  <Drawer open shouldScaleBackground={false}>
+    <DrawerTrigger asChild>
+      <Button>Plan dinner</Button>
+    </DrawerTrigger>
+    <DrawerContent>
+      <DrawerHeader>
+        <DrawerTitle className="font-serif">Plan Tuesday</DrawerTitle>
+        <DrawerDescription>
+          Pick a dinner for 4 March from your household&apos;s list.
+        </DrawerDescription>
+      </DrawerHeader>
+      <div className="flex flex-col gap-2 px-1 py-2">
+        {[
+          { name: "Thai green curry", tags: ["Asian", "Quick"] },
+          { name: "Mushroom risotto", tags: ["Vegetarian", "Comfort"] },
+          { name: "Fish tacos", tags: ["Fish"] },
+        ].map((dinner) => (
+          <button
+            key={dinner.name}
+            type="button"
+            className="hover:bg-accent border-border flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors"
+          >
+            <span className="font-serif text-base leading-tight">
+              {dinner.name}
+            </span>
+            <span className="flex flex-wrap gap-1">
+              {dinner.tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="text-xs">
+                  {tag}
+                </Badge>
+              ))}
+            </span>
+          </button>
+        ))}
+      </div>
+      <DrawerFooter>
+        <Button>Save to Tuesday</Button>
+        <DrawerClose asChild>
+          <Button variant="outline">Cancel</Button>
+        </DrawerClose>
+      </DrawerFooter>
+    </DrawerContent>
+  </Drawer>
+);

--- a/.design-sync/previews/FancyCombobox.tsx
+++ b/.design-sync/previews/FancyCombobox.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import { FancyCombobox, Label } from "@planeatrepeat/web";
+
+type Tag = { value: string; label: string };
+
+const asTags = (values: string[]): Tag[] =>
+  values.map((value) => ({ value, label: value }));
+
+// Kept short on purpose: the option list is capped at 35dvh, and a taller
+// list would be cut mid-row in the preview card.
+const householdTags = asTags([
+  "Vegetarian",
+  "20 min",
+  "Family favourite",
+  "Friday",
+  "Leftovers",
+]);
+
+const useTagState = (initial: string[]) => {
+  const [selected, setSelected] = React.useState<Tag[]>(asTags(initial));
+
+  return {
+    selected,
+    select: (option: Tag) => setSelected((current) => [...current, option]),
+    unselect: (option: Tag) =>
+      setSelected((current) =>
+        current.filter((tag) => tag.value !== option.value),
+      ),
+    removeLast: () => setSelected((current) => current.slice(0, -1)),
+    createNew: (value: string) =>
+      setSelected((current) => [...current, { value, label: value }]),
+  };
+};
+
+export const WithTags = () => {
+  const tags = useTagState(["Vegetarian", "20 min"]);
+
+  return (
+    <div className="w-80 space-y-2">
+      <Label>Tags</Label>
+      <FancyCombobox
+        options={householdTags}
+        placeholder="Add tag…"
+        {...tags}
+      />
+    </div>
+  );
+};
+
+export const Empty = () => {
+  const tags = useTagState([]);
+
+  return (
+    <div className="w-80 space-y-2">
+      <Label>Tags</Label>
+      <FancyCombobox
+        options={householdTags}
+        placeholder="Add tag…"
+        {...tags}
+      />
+    </div>
+  );
+};
+
+// The dropdown is driven by the input's own focus state — there is no `open`
+// prop — so the story focuses the input on mount to show the option list.
+export const OpenOptions = () => {
+  const tags = useTagState(["Vegetarian"]);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    containerRef.current?.querySelector("input")?.focus();
+  }, []);
+
+  return (
+    <div ref={containerRef} className="w-80 space-y-2">
+      <Label>Tags</Label>
+      <FancyCombobox
+        options={householdTags}
+        placeholder="Add tag…"
+        {...tags}
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/Form.tsx
+++ b/.design-sync/previews/Form.tsx
@@ -1,0 +1,188 @@
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Textarea,
+} from "@planeatrepeat/web";
+
+export const HouseholdSettings = () => {
+  const form = useForm({
+    defaultValues: {
+      name: "The Hollunds",
+      slug: "the-hollunds",
+      importInstructions: "",
+    },
+  });
+
+  return (
+    <Card className="max-w-md">
+      <CardHeader>
+        <CardTitle>Edit household</CardTitle>
+        <CardDescription>
+          Everyone in the household shares these dinners and this week&apos;s
+          plan.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(() => undefined)}
+            className="space-y-8"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Household name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Household slug</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                  <FormDescription>
+                    The slug identifies your household. It is part of the URL
+                    for your invitations.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="importInstructions"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Recipe import instructions</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      maxLength={1000}
+                      placeholder="Keep steps short and explain techniques for beginners"
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Shape every imported recipe.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-between">
+              <Button type="submit" variant="outline">
+                Save changes
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const SingleField = () => {
+  const form = useForm({ defaultValues: { name: "" } });
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(() => undefined)}
+        className="max-w-sm space-y-4"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Dinner name</FormLabel>
+              <FormControl>
+                <Input placeholder="Tomato pasta" {...field} />
+              </FormControl>
+              <FormDescription>
+                This is what you will see in the weekly plan.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Save dinner</Button>
+      </form>
+    </Form>
+  );
+};
+
+export const WithValidationError = () => {
+  const form = useForm({ defaultValues: { name: "Th", link: "matprat" } });
+
+  React.useEffect(() => {
+    form.setError("name", { message: "Name must be at least 3 characters" });
+    form.setError("link", { message: "Enter a valid URL" });
+  }, [form]);
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(() => undefined)}
+        className="max-w-sm space-y-6"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Household name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="link"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Recipe link</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormDescription>Optional — where you found it.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" variant="outline">
+          Save changes
+        </Button>
+      </form>
+    </Form>
+  );
+};

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,80 @@
+import * as React from "react";
+import { Button, Input, Label } from "@planeatrepeat/web";
+import { Search, Wand2 } from "lucide-react";
+
+export const Basic = () => (
+  <div className="max-w-sm space-y-2">
+    <Label htmlFor="dinner-name">Dinner name</Label>
+    <Input id="dinner-name" placeholder="Tomato pasta" />
+  </div>
+);
+
+export const WithValue = () => (
+  <div className="max-w-sm space-y-2">
+    <Label htmlFor="household-name">Household name</Label>
+    <Input id="household-name" defaultValue="The Hollunds" />
+  </div>
+);
+
+export const Types = () => (
+  <div className="max-w-sm space-y-4">
+    <div className="space-y-2">
+      <Label htmlFor="recipe-link">Recipe link</Label>
+      <Input
+        id="recipe-link"
+        type="url"
+        placeholder="https://"
+        className="h-12 bg-white"
+      />
+    </div>
+    <div className="space-y-2">
+      <Label htmlFor="servings">Servings</Label>
+      <Input id="servings" type="number" defaultValue={4} className="w-24" />
+    </div>
+    <div className="flex gap-2">
+      <Input placeholder="Search dinners" />
+      <Button size="icon" aria-label="Search dinners">
+        <Search />
+      </Button>
+    </div>
+  </div>
+);
+
+export const WithDescriptionAndError = () => (
+  <div className="max-w-sm space-y-4">
+    <div className="space-y-2">
+      <Label htmlFor="household-slug">Household slug</Label>
+      <Input id="household-slug" defaultValue="the-hollunds" />
+      <p className="text-muted-foreground text-sm">
+        The slug is part of the URL for your household invitations.
+      </p>
+    </div>
+    <div className="space-y-2">
+      <Label htmlFor="short-slug" className="text-destructive">
+        Household slug
+      </Label>
+      <Input id="short-slug" defaultValue="th" aria-invalid />
+      <p className="text-destructive text-sm font-medium">
+        Slug must be at least 3 characters
+      </p>
+    </div>
+  </div>
+);
+
+export const Disabled = () => (
+  <div className="max-w-sm space-y-4">
+    <div className="space-y-2">
+      <Label htmlFor="importing-link">Recipe link</Label>
+      <Input
+        id="importing-link"
+        type="url"
+        defaultValue="https://matprat.no/oppskrifter/fiskesuppe"
+        disabled
+      />
+    </div>
+    <Button disabled>
+      <Wand2 />
+      Importing…
+    </Button>
+  </div>
+);

--- a/.design-sync/previews/Label.tsx
+++ b/.design-sync/previews/Label.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { Input, Label, Textarea } from "@planeatrepeat/web";
+
+export const Basic = () => (
+  <div className="max-w-sm space-y-2">
+    <Label htmlFor="household-slug">Household URL</Label>
+    <Input id="household-slug" defaultValue="the-hollunds" />
+  </div>
+);
+
+export const Standalone = () => (
+  <div className="flex flex-col gap-3">
+    <Label>Dinner name</Label>
+    <Label>Recipe import instructions</Label>
+    <Label className="text-destructive">Household slug</Label>
+    <Label className="text-muted-foreground">Tags</Label>
+  </div>
+);
+
+export const FieldStack = () => (
+  <div className="max-w-sm space-y-4">
+    <div className="space-y-2">
+      <Label htmlFor="stack-name">Dinner name</Label>
+      <Input id="stack-name" defaultValue="Fish tacos" />
+    </div>
+    <div className="space-y-2">
+      <Label htmlFor="stack-notes">Notes</Label>
+      <Textarea
+        id="stack-notes"
+        rows={3}
+        placeholder="Anything worth remembering…"
+      />
+    </div>
+  </div>
+);
+
+// Input first in the DOM so `peer-disabled:` can reach the label;
+// flex-col-reverse puts the label back on top visually.
+export const DisabledField = () => (
+  <div className="flex max-w-sm flex-col-reverse gap-2">
+    <Input
+      id="disabled-slug"
+      className="peer"
+      defaultValue="the-hollunds"
+      disabled
+    />
+    <Label htmlFor="disabled-slug">Household URL</Label>
+  </div>
+);

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import {
+  Label,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@planeatrepeat/web";
+
+// SelectContent portals to document.body, so the trigger is what keeps the
+// card root non-empty while `defaultOpen` shows the list.
+export const MemberRole = () => (
+  <div className="w-56 space-y-2">
+    <Label htmlFor="member-role">Role</Label>
+    <Select defaultValue="MEMBER" defaultOpen>
+      <SelectTrigger id="member-role" className="w-[120px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="ADMIN">Admin</SelectItem>
+        <SelectItem value="MEMBER">Member</SelectItem>
+      </SelectContent>
+    </Select>
+  </div>
+);
+
+export const Grouped = () => (
+  <div className="w-60 space-y-2">
+    <Label htmlFor="plan-day">Move dinner to</Label>
+    <Select defaultValue="thursday" defaultOpen>
+      <SelectTrigger id="plan-day" className="w-full">
+        <SelectValue placeholder="Pick a day" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>This week</SelectLabel>
+          <SelectItem value="monday">Monday</SelectItem>
+          <SelectItem value="tuesday">Tuesday</SelectItem>
+          <SelectItem value="wednesday">Wednesday</SelectItem>
+          <SelectItem value="thursday">Thursday</SelectItem>
+          <SelectItem value="friday">Friday</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  </div>
+);
+
+export const Closed = () => (
+  <div className="w-60 space-y-2">
+    <Label htmlFor="closed-role">Role</Label>
+    <Select defaultValue="ADMIN">
+      <SelectTrigger id="closed-role" className="w-[120px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="ADMIN">Admin</SelectItem>
+        <SelectItem value="MEMBER">Member</SelectItem>
+      </SelectContent>
+    </Select>
+  </div>
+);
+
+export const PlaceholderAndDisabled = () => (
+  <div className="w-60 space-y-4">
+    <div className="space-y-2">
+      <Label htmlFor="empty-week">Week</Label>
+      <Select>
+        <SelectTrigger id="empty-week" className="w-full">
+          <SelectValue placeholder="Pick a week" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="this">This week</SelectItem>
+          <SelectItem value="next">Next week</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+    <div className="space-y-2">
+      <Label htmlFor="owner-role">Role</Label>
+      <Select defaultValue="ADMIN" disabled>
+        <SelectTrigger id="owner-role" className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="ADMIN">Admin</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Separator.tsx
+++ b/.design-sync/previews/Separator.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Separator,
+} from "@planeatrepeat/web";
+
+export const BetweenSections = () => (
+  <Card className="w-80">
+    <CardHeader>
+      <CardTitle className="font-serif text-xl">Household settings</CardTitle>
+    </CardHeader>
+    <CardContent className="text-sm">
+      <div className="space-y-1">
+        <p className="font-medium">Name</p>
+        <p className="text-muted-foreground">Hollund-Nilsen</p>
+      </div>
+      <Separator className="my-4" />
+      <div className="space-y-1">
+        <p className="font-medium">Members</p>
+        <p className="text-muted-foreground">Aslak, Marte, Jonas</p>
+      </div>
+      <Separator className="my-4" />
+      <div className="space-y-1">
+        <p className="font-medium">Invite link</p>
+        <p className="text-muted-foreground">Expires in 6 days</p>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+export const VerticalMeta = () => (
+  <div className="text-muted-foreground flex h-6 items-center space-x-3 text-sm">
+    <span>Vegetarian</span>
+    <Separator orientation="vertical" className="h-4" />
+    <span>20 min</span>
+    <Separator orientation="vertical" className="h-4" />
+    <span>Serves 4</span>
+    <Separator orientation="vertical" className="h-4" />
+    <span>Cooked 12 times</span>
+  </div>
+);
+
+export const WeekList = () => (
+  <div className="w-72 text-sm">
+    {["Monday", "Tuesday", "Wednesday"].map((day, i) => (
+      <React.Fragment key={day}>
+        {i > 0 && <Separator />}
+        <div className="flex items-center justify-between py-3">
+          <span className="text-muted-foreground">{day}</span>
+          <span>
+            {["Tomato pasta", "Chicken curry", "Lentil soup"][i]}
+          </span>
+        </div>
+      </React.Fragment>
+    ))}
+  </div>
+);

--- a/.design-sync/previews/Sheet.tsx
+++ b/.design-sync/previews/Sheet.tsx
@@ -1,0 +1,100 @@
+import * as React from "react";
+import {
+  Badge,
+  Button,
+  Input,
+  Label,
+  Separator,
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@planeatrepeat/web";
+import { CalendarDays, SlidersHorizontal, UtensilsCrossed } from "lucide-react";
+
+// `open` is set so the panel renders in the card. SheetContent portals to
+// document.body, so the trigger is what keeps the card root non-empty.
+export const Filters = () => (
+  <Sheet open>
+    <SheetTrigger asChild>
+      <Button variant="outline">
+        <SlidersHorizontal className="mr-2 h-4 w-4" />
+        Filters
+      </Button>
+    </SheetTrigger>
+    <SheetContent side="right">
+      <SheetHeader>
+        <SheetTitle className="font-serif">Filter dinners</SheetTitle>
+        <SheetDescription>
+          Narrow your household&apos;s dinners by name or tag.
+        </SheetDescription>
+      </SheetHeader>
+      <div className="space-y-4 py-6">
+        <div className="space-y-2">
+          <Label htmlFor="sheet-dinner-search">Search</Label>
+          <Input id="sheet-dinner-search" defaultValue="curry" />
+        </div>
+        <Separator />
+        <div className="space-y-2">
+          <Label>Tags</Label>
+          <div className="flex flex-wrap gap-2">
+            {[
+              { tag: "Vegetarian", on: true },
+              { tag: "Quick", on: true },
+              { tag: "Pasta", on: false },
+              { tag: "Asian", on: false },
+              { tag: "Comfort", on: false },
+            ].map(({ tag, on }) => (
+              <Badge
+                key={tag}
+                variant="secondary"
+                className={
+                  on
+                    ? "border-primary bg-primary/10 cursor-pointer border"
+                    : "cursor-pointer"
+                }
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </div>
+      <SheetFooter>
+        <SheetClose asChild>
+          <Button variant="secondary">Clear</Button>
+        </SheetClose>
+        <Button>Show 12 dinners</Button>
+      </SheetFooter>
+    </SheetContent>
+  </Sheet>
+);
+
+// `side="left"` — the placement the app uses for its mobile navigation sheet.
+export const LeftNavigation = () => (
+  <Sheet open>
+    <SheetTrigger asChild>
+      <Button variant="ghost">Menu</Button>
+    </SheetTrigger>
+    <SheetContent side="left">
+      <SheetHeader>
+        <SheetTitle className="font-serif">Hollund household</SheetTitle>
+        <SheetDescription>Four people, one weekly plan.</SheetDescription>
+      </SheetHeader>
+      <nav className="flex flex-col gap-1 py-6">
+        <span className="bg-accent text-accent-foreground flex items-center gap-2 rounded-lg px-3 py-2 text-sm">
+          <CalendarDays className="h-4 w-4" />
+          This week
+        </span>
+        <span className="hover:bg-accent flex items-center gap-2 rounded-lg px-3 py-2 text-sm">
+          <UtensilsCrossed className="h-4 w-4" />
+          Dinners
+        </span>
+      </nav>
+    </SheetContent>
+  </Sheet>
+);

--- a/.design-sync/previews/Sidebar.tsx
+++ b/.design-sync/previews/Sidebar.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@planeatrepeat/web";
+import { CalendarDays, Settings, UtensilsCrossed } from "lucide-react";
+
+const nav = [
+  { title: "Plan", icon: CalendarDays, active: true },
+  { title: "Dinners", icon: UtensilsCrossed, active: false },
+  { title: "Settings", icon: Settings, active: false },
+];
+
+// The whole family needs a SidebarProvider ancestor, so every story here is a
+// full shell. `collapsible="none"` keeps the panel in flow (the default
+// off-canvas panel is `position: fixed`, which a small card cannot frame).
+export const AppShell = () => (
+  <SidebarProvider
+    style={{ minHeight: 0, height: 384 }}
+    className="w-full overflow-hidden rounded-lg border"
+  >
+    <Sidebar
+      collapsible="none"
+      className="border-sidebar-border h-full border-r"
+    >
+      <SidebarHeader className="px-3 py-3">
+        <span className="font-serif text-base">PlanEatRepeat</span>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Hollund household</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {nav.map((item) => (
+                <SidebarMenuItem key={item.title}>
+                  <SidebarMenuButton isActive={item.active}>
+                    <item.icon />
+                    <span>{item.title}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarFooter>
+        <div className="flex w-full p-2">
+          <SidebarTrigger />
+        </div>
+      </SidebarFooter>
+    </Sidebar>
+    <SidebarInset className="p-6">
+      <h2 className="font-serif text-xl">This week</h2>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Wednesday 15 May — Tomato pasta
+      </p>
+    </SidebarInset>
+  </SidebarProvider>
+);
+
+// `side="right"` mirrors the panel; the app keeps the border on the inner edge.
+export const RightSide = () => (
+  <SidebarProvider
+    style={{ minHeight: 0, height: 320 }}
+    className="w-full overflow-hidden rounded-lg border"
+  >
+    <SidebarInset className="p-6">
+      <h2 className="font-serif text-xl">Fish tacos</h2>
+      <p className="text-muted-foreground mt-1 text-sm">
+        Planned for Friday 17 May
+      </p>
+    </SidebarInset>
+    <Sidebar
+      side="right"
+      collapsible="none"
+      className="border-sidebar-border h-full border-l"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Up next</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {["Fish tacos", "Chicken curry with rice", "Tomato pasta"].map(
+                (dinner, i) => (
+                  <SidebarMenuItem key={dinner}>
+                    <SidebarMenuButton isActive={i === 0}>
+                      <UtensilsCrossed />
+                      <span>{dinner}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ),
+              )}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarFooter.tsx
+++ b/.design-sync/previews/SidebarFooter.tsx
@@ -1,0 +1,97 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarSeparator,
+  SidebarTrigger,
+} from "@planeatrepeat/web";
+import { CalendarDays, LogOut, Settings, UtensilsCrossed } from "lucide-react";
+
+const nav = [
+  { title: "Plan", icon: CalendarDays, active: true },
+  { title: "Dinners", icon: UtensilsCrossed, active: false },
+  { title: "Settings", icon: Settings, active: false },
+];
+
+const Rows = () => (
+  <SidebarContent>
+    <SidebarGroup>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {nav.map((item) => (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton isActive={item.active}>
+                <item.icon />
+                <span>{item.title}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  </SidebarContent>
+);
+
+// SidebarFooter pins to the bottom of the panel — SidebarContent takes the
+// remaining height. This is the app's real footer: the collapse trigger.
+export const CollapseTrigger = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 320 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <Rows />
+      <SidebarSeparator />
+      <SidebarFooter>
+        <div className="flex w-full p-2">
+          <SidebarTrigger />
+        </div>
+      </SidebarFooter>
+    </Sidebar>
+  </SidebarProvider>
+);
+
+// A signed-in user block is the other common footer: an avatar row plus a way
+// out, both styled from the sidebar tokens rather than the page surface.
+export const UserBlock = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 320 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <Rows />
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg">
+              <div className="bg-sidebar-accent text-sidebar-accent-foreground flex size-8 items-center justify-center rounded-full text-xs font-medium">
+                AH
+              </div>
+              <div className="flex flex-1 flex-col text-left leading-tight">
+                <span className="truncate text-sm font-medium">Aslak</span>
+                <span className="text-sidebar-foreground/70 truncate text-xs">
+                  Hollund household
+                </span>
+              </div>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="sm">
+              <LogOut />
+              <span>Sign out</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarGroup.tsx
+++ b/.design-sync/previews/SidebarGroup.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarSeparator,
+} from "@planeatrepeat/web";
+import { CalendarDays, Plus, Settings, UtensilsCrossed, Users } from "lucide-react";
+
+// A group is one titled block inside SidebarContent. Two of them show the
+// spacing the group owns; both need the provider + Sidebar above them.
+export const TwoGroups = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 320 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Plan</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton isActive>
+                  <CalendarDays />
+                  <span>This week</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <UtensilsCrossed />
+                  <span>Dinners</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarSeparator />
+        <SidebarGroup>
+          <SidebarGroupLabel>Household</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <Users />
+                  <span>Members</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <Settings />
+                  <span>Settings</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);
+
+// SidebarGroup is `relative`, which is what lets SidebarGroupAction pin itself
+// to the group's top-right corner.
+export const WithAction = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 256 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Dinners</SidebarGroupLabel>
+          <SidebarGroupAction title="New dinner">
+            <Plus />
+          </SidebarGroupAction>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {["Tomato pasta", "Fish tacos", "Chicken curry with rice"].map(
+                (dinner) => (
+                  <SidebarMenuItem key={dinner}>
+                    <SidebarMenuButton>
+                      <UtensilsCrossed />
+                      <span>{dinner}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ),
+              )}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarGroupLabel.tsx
+++ b/.design-sync/previews/SidebarGroupLabel.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+} from "@planeatrepeat/web";
+import { CalendarDays, ChefHat, Settings, UtensilsCrossed } from "lucide-react";
+
+// The label is the small, dimmed heading over a group's rows. It reads as a
+// label only in place, so the preview is the group it titles.
+export const PlanGroup = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 240 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Plan</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton isActive>
+                  <CalendarDays />
+                  <span>This week</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <UtensilsCrossed />
+                  <span>Dinners</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <Settings />
+                  <span>Settings</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);
+
+// The label accepts an icon child (auto-sized to 16px) and `asChild` when the
+// heading itself should be the clickable element.
+export const WithIcon = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 240 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>
+            <ChefHat />
+            <span className="ml-2">Hollund household</span>
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {["Tomato pasta", "Fish tacos"].map((dinner) => (
+                <SidebarMenuItem key={dinner}>
+                  <SidebarMenuButton>
+                    <UtensilsCrossed />
+                    <span>{dinner}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarHeader.tsx
+++ b/.design-sync/previews/SidebarHeader.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarSeparator,
+} from "@planeatrepeat/web";
+import { CalendarDays, ChevronsUpDown, Settings, UtensilsCrossed } from "lucide-react";
+
+const nav = [
+  { title: "Plan", icon: CalendarDays, active: true },
+  { title: "Dinners", icon: UtensilsCrossed, active: false },
+  { title: "Settings", icon: Settings, active: false },
+];
+
+const Rows = () => (
+  <SidebarContent>
+    <SidebarGroup>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {nav.map((item) => (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton isActive={item.active}>
+                <item.icon />
+                <span>{item.title}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  </SidebarContent>
+);
+
+// SidebarHeader is the pinned block above the scrolling content — the app puts
+// the product wordmark there. It needs the provider + Sidebar around it.
+export const Wordmark = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 320 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarHeader className="px-3 py-3">
+        <span className="font-serif text-base leading-none">PlanEatRepeat</span>
+      </SidebarHeader>
+      <SidebarSeparator />
+      <Rows />
+    </Sidebar>
+  </SidebarProvider>
+);
+
+// The header also hosts the household switcher, built from a menu button so it
+// picks up the sidebar accent on hover.
+export const HouseholdSwitcher = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 320 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg">
+              <div className="bg-sidebar-primary text-sidebar-primary-foreground flex size-8 items-center justify-center rounded-md">
+                <UtensilsCrossed className="size-4" />
+              </div>
+              <div className="flex flex-1 flex-col text-left leading-tight">
+                <span className="truncate text-sm font-medium">
+                  Hollund household
+                </span>
+                <span className="text-sidebar-foreground/70 truncate text-xs">
+                  4 members
+                </span>
+              </div>
+              <ChevronsUpDown className="ml-auto" />
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <Rows />
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarMenuItem.tsx
+++ b/.design-sync/previews/SidebarMenuItem.tsx
@@ -1,0 +1,101 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+} from "@planeatrepeat/web";
+import { CalendarDays, MoreHorizontal, Settings, UtensilsCrossed } from "lucide-react";
+
+// SidebarMenuItem is the <li> wrapper: it is `relative` and opens the
+// `group/menu-item` scope every row decoration hangs off. Rows only look right
+// inside SidebarMenu, inside a Sidebar, inside the provider.
+export const NavigationRows = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 240 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Plan Eat Repeat</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton isActive>
+                  <CalendarDays />
+                  <span>Plan</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <UtensilsCrossed />
+                  <span>Dinners</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <Settings />
+                  <span>Settings</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);
+
+// The item is also the positioning context for a badge or a row action — both
+// absolutely position themselves against it.
+export const WithBadgeAndAction = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 240 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Dinners</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <UtensilsCrossed />
+                  <span>Tomato pasta</span>
+                </SidebarMenuButton>
+                <SidebarMenuBadge>4</SidebarMenuBadge>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton isActive>
+                  <UtensilsCrossed />
+                  <span>Fish tacos</span>
+                </SidebarMenuButton>
+                <SidebarMenuAction title="More">
+                  <MoreHorizontal />
+                </SidebarMenuAction>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <UtensilsCrossed />
+                  <span>Chicken curry with rice</span>
+                </SidebarMenuButton>
+                <SidebarMenuBadge>2</SidebarMenuBadge>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarMenuSkeleton.tsx
+++ b/.design-sync/previews/SidebarMenuSkeleton.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarProvider,
+} from "@planeatrepeat/web";
+
+// What the Dinners list shows while the household's dinners are still loading:
+// one skeleton row per expected item, each 8px tall like the real menu button.
+// `showIcon` reserves the leading icon square.
+export const LoadingDinners = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 288 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Dinners</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {[0, 1, 2, 3, 4].map((i) => (
+                <SidebarMenuItem key={i}>
+                  <SidebarMenuSkeleton showIcon />
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);
+
+// Without `showIcon` the rows are text-only — used for the plan list, whose
+// real rows carry a date rather than an icon.
+export const LoadingPlan = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 224 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>This week</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {[0, 1, 2, 3].map((i) => (
+                <SidebarMenuItem key={i}>
+                  <SidebarMenuSkeleton />
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarMenuSub.tsx
+++ b/.design-sync/previews/SidebarMenuSub.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+} from "@planeatrepeat/web";
+import { CalendarDays, ChevronDown, UtensilsCrossed } from "lucide-react";
+
+// SidebarMenuSub is the nested <ul> under an expanded row: it draws the
+// indent guide (`border-l border-sidebar-border`) that ties the children to
+// their parent. It only makes sense inside a SidebarMenuItem.
+export const ExpandedDinners = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 288 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Plan Eat Repeat</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <CalendarDays />
+                  <span>Plan</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton isActive>
+                  <UtensilsCrossed />
+                  <span>Dinners</span>
+                  <ChevronDown className="ml-auto" />
+                </SidebarMenuButton>
+                <SidebarMenuSub>
+                  {["Tomato pasta", "Fish tacos", "Chicken curry with rice"].map(
+                    (dinner, i) => (
+                      <SidebarMenuSubItem key={dinner}>
+                        <SidebarMenuSubButton isActive={i === 0}>
+                          <span>{dinner}</span>
+                        </SidebarMenuSubButton>
+                      </SidebarMenuSubItem>
+                    ),
+                  )}
+                </SidebarMenuSub>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);
+
+// Two expanded rows show how the indent guide reads when sub-lists stack.
+export const TwoLevels = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 320 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>This week</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <CalendarDays />
+                  <span>Monday 13 May</span>
+                </SidebarMenuButton>
+                <SidebarMenuSub>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton>
+                      <span>Tomato pasta</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                </SidebarMenuSub>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton isActive>
+                  <CalendarDays />
+                  <span>Wednesday 15 May</span>
+                </SidebarMenuButton>
+                <SidebarMenuSub>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton isActive>
+                      <span>Fish tacos</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton>
+                      <span>Green salad</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                </SidebarMenuSub>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarMenuSubButton.tsx
+++ b/.design-sync/previews/SidebarMenuSubButton.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+} from "@planeatrepeat/web";
+import { ChevronDown, Fish, Soup, UtensilsCrossed } from "lucide-react";
+
+// The nested row itself: an <a> at 28px with the sidebar accent for hover and
+// for `isActive`. It needs SidebarMenuSub above it for the indent guide.
+export const ActiveAndDefault = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 288 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Dinners</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton isActive>
+                  <UtensilsCrossed />
+                  <span>Friday favourites</span>
+                  <ChevronDown className="ml-auto" />
+                </SidebarMenuButton>
+                <SidebarMenuSub>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton isActive>
+                      <Fish />
+                      <span>Fish tacos</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton>
+                      <Soup />
+                      <span>Chicken curry with rice</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton>
+                      <UtensilsCrossed />
+                      <span>Tomato pasta</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                </SidebarMenuSub>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);
+
+// `size="sm"` drops the row to 12px type — used when a sub-list gets long.
+export const SmallSize = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 288 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>This week</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <UtensilsCrossed />
+                  <span>Planned dinners</span>
+                </SidebarMenuButton>
+                <SidebarMenuSub>
+                  {[
+                    "Mon — Tomato pasta",
+                    "Tue — Lentil soup",
+                    "Wed — Fish tacos",
+                    "Thu — Halloumi wraps",
+                    "Fri — Chicken curry",
+                  ].map((row, i) => (
+                    <SidebarMenuSubItem key={row}>
+                      <SidebarMenuSubButton size="sm" isActive={i === 2}>
+                        <span>{row}</span>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  ))}
+                </SidebarMenuSub>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarMenuSubItem.tsx
+++ b/.design-sync/previews/SidebarMenuSubItem.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+} from "@planeatrepeat/web";
+import { ChevronDown, UtensilsCrossed } from "lucide-react";
+
+// SidebarMenuSubItem is the bare <li> for one nested row. It carries no styling
+// of its own, so it is only legible as the list rows inside SidebarMenuSub.
+export const NestedRows = () => (
+  <SidebarProvider style={{ minHeight: 0 }} className="w-auto">
+    <Sidebar
+      collapsible="none"
+      style={{ height: 288 }}
+      className="border-sidebar-border w-64 overflow-hidden rounded-lg border"
+    >
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Dinners</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton isActive>
+                  <UtensilsCrossed />
+                  <span>Vegetarian</span>
+                  <ChevronDown className="ml-auto" />
+                </SidebarMenuButton>
+                <SidebarMenuSub>
+                  {[
+                    "Tomato pasta",
+                    "Lentil soup",
+                    "Halloumi wraps",
+                    "Green salad",
+                  ].map((dinner, i) => (
+                    <SidebarMenuSubItem key={dinner}>
+                      <SidebarMenuSubButton isActive={i === 1}>
+                        <span>{dinner}</span>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  ))}
+                </SidebarMenuSub>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/SidebarProvider.tsx
+++ b/.design-sync/previews/SidebarProvider.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@planeatrepeat/web";
+import { CalendarDays, Settings, UtensilsCrossed } from "lucide-react";
+
+const nav = [
+  { title: "Plan", icon: CalendarDays, active: true },
+  { title: "Dinners", icon: UtensilsCrossed, active: false },
+  { title: "Settings", icon: Settings, active: false },
+];
+
+const Nav = () => (
+  <SidebarContent>
+    <SidebarGroup>
+      <SidebarGroupLabel>Plan Eat Repeat</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {nav.map((item) => (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton isActive={item.active}>
+                <item.icon />
+                <span>{item.title}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  </SidebarContent>
+);
+
+// The provider owns open/collapsed state and hands every descendant the sidebar
+// context. It renders the flex row that pairs the panel with SidebarInset, so
+// the honest preview is the whole app layout.
+export const AppLayout = () => (
+  <SidebarProvider
+    style={{ minHeight: 0, height: 320 }}
+    className="w-full overflow-hidden rounded-lg border"
+  >
+    <Sidebar
+      collapsible="none"
+      className="border-sidebar-border h-full border-r"
+    >
+      <Nav />
+    </Sidebar>
+    <SidebarInset>
+      <header className="flex items-center gap-2 border-b p-3">
+        <SidebarTrigger />
+        <span className="font-serif text-base">This week</span>
+      </header>
+      <div className="text-muted-foreground p-6 text-sm">
+        Wednesday 15 May — Tomato pasta
+      </div>
+    </SidebarInset>
+  </SidebarProvider>
+);
+
+// The provider publishes `--sidebar-width` on its wrapper, so a narrower rail
+// is a style override on the provider rather than a prop on Sidebar.
+export const CustomWidth = () => (
+  <SidebarProvider
+    style={{ "--sidebar-width": "13rem", minHeight: 0, height: 288 } as React.CSSProperties}
+    className="w-full overflow-hidden rounded-lg border"
+  >
+    <Sidebar
+      collapsible="none"
+      className="border-sidebar-border h-full border-r"
+    >
+      <Nav />
+    </Sidebar>
+    <SidebarInset className="p-6">
+      <p className="text-muted-foreground text-sm">
+        A 13rem rail leaves more room for the week grid.
+      </p>
+    </SidebarInset>
+  </SidebarProvider>
+);

--- a/.design-sync/previews/Skeleton.tsx
+++ b/.design-sync/previews/Skeleton.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { Card, CardContent, CardHeader, Skeleton } from "@planeatrepeat/web";
+
+export const LoadingDinnerCard = () => (
+  <Card className="flex w-56 flex-col justify-between">
+    <CardHeader className="p-4 pb-2">
+      <Skeleton className="h-5 w-40" />
+    </CardHeader>
+    <CardContent className="p-4 pt-2">
+      <div className="flex gap-2">
+        <Skeleton className="h-5 w-20 rounded-full" />
+        <Skeleton className="h-5 w-14 rounded-full" />
+      </div>
+    </CardContent>
+  </Card>
+);
+
+export const LoadingDinnerGrid = () => (
+  <div className="grid max-w-2xl grid-cols-3 gap-3">
+    {[0, 1, 2, 3, 4, 5].map((i) => (
+      <Card key={i} className="flex min-h-[100px] flex-col justify-between">
+        <CardHeader className="p-4 pb-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </CardHeader>
+        <CardContent className="p-4 pt-2">
+          <Skeleton className="h-5 w-16 rounded-full" />
+        </CardContent>
+      </Card>
+    ))}
+  </div>
+);
+
+export const LoadingMemberList = () => (
+  <div className="w-80 space-y-4">
+    {[0, 1, 2].map((i) => (
+      <div key={i} className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-full" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      </div>
+    ))}
+  </div>
+);

--- a/.design-sync/previews/Textarea.tsx
+++ b/.design-sync/previews/Textarea.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import { Button, Label, Textarea } from "@planeatrepeat/web";
+
+export const Basic = () => (
+  <div className="max-w-sm space-y-2">
+    <Label htmlFor="dinner-notes">Notes</Label>
+    <Textarea
+      id="dinner-notes"
+      rows={4}
+      placeholder="Anything worth remembering…"
+    />
+  </div>
+);
+
+export const WithDescription = () => (
+  <div className="max-w-sm space-y-2">
+    <Label htmlFor="import-instructions">Recipe import instructions</Label>
+    <Textarea
+      id="import-instructions"
+      maxLength={1000}
+      placeholder="Keep steps short and explain techniques for beginners"
+    />
+    <p className="text-muted-foreground text-sm">
+      Shape every imported recipe. For example: “Keep steps short”, or “Explain
+      techniques for beginners”.
+    </p>
+  </div>
+);
+
+export const Filled = () => (
+  <div className="max-w-sm space-y-3">
+    <div className="space-y-2">
+      <Label htmlFor="paste-recipe">Paste recipe text</Label>
+      <Textarea
+        id="paste-recipe"
+        className="min-h-40 bg-white text-[15px]"
+        defaultValue={
+          "Chicken curry with rice\n\n400 g chicken thighs\n2 tbsp curry paste\n400 ml coconut milk\n\nSimmer 20 minutes, serve with rice."
+        }
+      />
+    </div>
+    <Button>Import pasted recipe</Button>
+  </div>
+);
+
+export const WithError = () => (
+  <div className="max-w-sm space-y-2">
+    <Label htmlFor="too-long-notes" className="text-destructive">
+      Recipe import instructions
+    </Label>
+    <Textarea
+      id="too-long-notes"
+      aria-invalid
+      defaultValue="Write every instruction in Norwegian, list the equipment first, explain each technique for a complete beginner, and always add a suggested side dish…"
+    />
+    <p className="text-destructive text-sm font-medium">
+      Instructions must be 1000 characters or fewer
+    </p>
+  </div>
+);
+
+export const Disabled = () => (
+  <div className="max-w-sm space-y-2">
+    <Label htmlFor="disabled-notes">Notes</Label>
+    <Textarea
+      id="disabled-notes"
+      disabled
+      defaultValue="Double the sauce — the kids always want extra."
+    />
+  </div>
+);

--- a/.design-sync/previews/Toast.tsx
+++ b/.design-sync/previews/Toast.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@planeatrepeat/web";
+
+// The Radix toast root portals into the viewport, and the app's viewport is
+// `fixed` to the screen corner. For a static preview card we keep the same
+// components but pin the viewport in flow so it photographs inside the cell.
+const ToastFrame = ({ children }: { children: React.ReactNode }) => (
+  <ToastProvider duration={Infinity}>
+    {children}
+    <ToastViewport className="static flex-col p-0" />
+  </ToastProvider>
+);
+
+export const Saved = () => (
+  <ToastFrame>
+    <Toast>
+      <div className="grid gap-1">
+        <ToastTitle>Dinner saved</ToastTitle>
+        <ToastDescription>
+          Fish tacos was added to Thursday.
+        </ToastDescription>
+      </div>
+      <ToastClose className="opacity-100" />
+    </Toast>
+  </ToastFrame>
+);
+
+export const Destructive = () => (
+  <ToastFrame>
+    <Toast variant="destructive">
+      <div className="grid gap-1">
+        <ToastTitle>Could not save dinner</ToastTitle>
+        <ToastDescription>
+          A dinner called Tomato pasta already exists in this household.
+        </ToastDescription>
+      </div>
+      <ToastClose className="opacity-100" />
+    </Toast>
+  </ToastFrame>
+);
+
+export const WithAction = () => (
+  <ToastFrame>
+    <Toast>
+      <div className="grid gap-1">
+        <ToastTitle>Removed from the plan</ToastTitle>
+        <ToastDescription>Lentil soup is off Wednesday.</ToastDescription>
+      </div>
+      <ToastAction altText="Undo removing the dinner">Undo</ToastAction>
+    </Toast>
+  </ToastFrame>
+);

--- a/.design-sync/previews/Toaster.tsx
+++ b/.design-sync/previews/Toaster.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@planeatrepeat/web";
+
+// `Toaster` takes no props and renders whatever `toast()` has queued, so a
+// static render of it is an empty viewport. These cells reproduce exactly the
+// markup Toaster emits for queued toasts (ToastProvider → Toast → title /
+// description / close → ToastViewport), with the viewport pinned in flow
+// instead of fixed to the screen corner so it photographs inside the cell.
+const ToasterFrame = ({ children }: { children: React.ReactNode }) => (
+  <ToastProvider duration={Infinity}>
+    {children}
+    <ToastViewport className="static flex-col gap-2 p-0" />
+  </ToastProvider>
+);
+
+export const QueuedToast = () => (
+  <ToasterFrame>
+    <Toast>
+      <div className="grid gap-1">
+        <ToastTitle>Role updated</ToastTitle>
+        <ToastDescription>Marte is now an admin.</ToastDescription>
+      </div>
+      <ToastClose className="opacity-100" />
+    </Toast>
+  </ToasterFrame>
+);
+
+export const StackedToasts = () => (
+  <ToasterFrame>
+    <Toast>
+      <div className="grid gap-1">
+        <ToastTitle>Dinner saved</ToastTitle>
+        <ToastDescription>Baked feta pasta added to Tuesday.</ToastDescription>
+      </div>
+      <ToastClose className="opacity-100" />
+    </Toast>
+    <Toast variant="destructive">
+      <div className="grid gap-1">
+        <ToastTitle>Invite expired</ToastTitle>
+        <ToastDescription>Send Jonas a new household link.</ToastDescription>
+      </div>
+      <ToastClose className="opacity-100" />
+    </Toast>
+  </ToasterFrame>
+);

--- a/.design-sync/previews/Tooltip.tsx
+++ b/.design-sync/previews/Tooltip.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@planeatrepeat/web";
+import { Info } from "lucide-react";
+
+// Every tooltip needs a TooltipProvider ancestor. `open` is set so the
+// content renders in the card; the trigger keeps the card root non-empty.
+export const Open = () => (
+  <TooltipProvider>
+    <Tooltip open>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <Info className="h-4 w-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Dinners you have not cooked recently</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+// `side="right"` on an icon-only action, the way a collapsed sidebar labels
+// its items.
+export const SideRight = () => (
+  <TooltipProvider>
+    <Tooltip open>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Plan Tuesday</Button>
+      </TooltipTrigger>
+      <TooltipContent side="right">Nothing planned yet</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,12 @@ generated
 
 # claude code local config
 .claude/
+
+# design-sync (claude.ai/design) — staged scripts, build output, machine state
+/.ds-sync/
+/ds-bundle/
+/.design-sync/.cache/
+/.design-sync/learnings/
+/.design-sync/node_modules
+/apps/web/design-sync-styles/candidates.txt
+/apps/web/design-sync-styles/ds.css

--- a/apps/web/design-sync-docs/Avatar.md
+++ b/apps/web/design-sync-docs/Avatar.md
@@ -1,0 +1,17 @@
+---
+category: Data Display
+---
+
+# Avatar
+
+A circular user image with a text fallback shown while the image loads or
+when it fails. Always render both children.
+
+```jsx
+<Avatar>
+  <AvatarImage src={user.imageUrl} alt={user.name} />
+  <AvatarFallback>AH</AvatarFallback>
+</Avatar>
+```
+
+Default size is `h-10 w-10`; override with `className="h-8 w-8"` for dense rows.

--- a/apps/web/design-sync-docs/AvatarFallback.md
+++ b/apps/web/design-sync-docs/AvatarFallback.md
@@ -1,0 +1,9 @@
+---
+category: Data Display
+---
+
+# AvatarFallback
+
+Part of the `Avatar` composition. Shown when the image is absent or still loading — usually the user's initials.
+
+See `Avatar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/AvatarImage.md
+++ b/apps/web/design-sync-docs/AvatarImage.md
@@ -1,0 +1,9 @@
+---
+category: Data Display
+---
+
+# AvatarImage
+
+Part of the `Avatar` composition. The image itself; hides automatically if the source fails to load.
+
+See `Avatar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Badge.md
+++ b/apps/web/design-sync-docs/Badge.md
@@ -1,0 +1,18 @@
+---
+category: Data Display
+---
+
+# Badge
+
+A small inline label — used in this app for dinner tags.
+
+```jsx
+<div className="flex flex-wrap gap-1">
+  <Badge variant="secondary">Vegetarian</Badge>
+  <Badge variant="outline">30 min</Badge>
+  <Badge>Favourite</Badge>
+</div>
+```
+
+- `variant`: `default` (primary fill) · `secondary` · `outline` · `destructive`
+- Badges do not wrap their own text — keep labels to a word or two.

--- a/apps/web/design-sync-docs/Button.md
+++ b/apps/web/design-sync-docs/Button.md
@@ -1,0 +1,23 @@
+---
+category: Actions
+---
+
+# Button
+
+The primary action control. Renders a `<button>`, or wraps an arbitrary child
+when `asChild` is set (use that to make a `next/link` look like a button).
+
+```jsx
+<div className="flex items-center gap-2">
+  <Button>Add dinner</Button>
+  <Button variant="secondary">Cancel</Button>
+  <Button variant="outline" size="sm">Edit</Button>
+  <Button variant="destructive">Delete</Button>
+  <Button variant="ghost" size="icon"><Plus className="h-4 w-4" /></Button>
+</div>
+```
+
+- `variant`: `default` (terracotta primary) · `secondary` · `outline` · `ghost` · `link` · `destructive`
+- `size`: `default` (h-10) · `sm` (h-9) · `lg` (h-11) · `icon` (square, h-10 w-10)
+- An `svg` child is auto-sized to `h-4 w-4`; no need to size icons yourself.
+- `disabled` dims to 50% opacity and blocks pointer events.

--- a/apps/web/design-sync-docs/Card.md
+++ b/apps/web/design-sync-docs/Card.md
@@ -1,0 +1,29 @@
+---
+category: Surfaces
+---
+
+# Card
+
+The main content container: white surface, `--radius` corners, hairline
+border. Nearly every list item and settings panel in this app is a Card.
+
+```jsx
+<Card>
+  <CardHeader>
+    <CardTitle>Create household</CardTitle>
+    <CardDescription>
+      Invite the people you cook for. You can add more later.
+    </CardDescription>
+  </CardHeader>
+  <CardContent>
+    <HouseholdForm />
+  </CardContent>
+  <CardFooter className="justify-end">
+    <Button>Save</Button>
+  </CardFooter>
+</Card>
+```
+
+Interactive cards in this app add
+`className="hover:bg-accent/50 cursor-pointer transition-colors"`, and a
+placeholder "add new" card uses `border-dashed bg-transparent`.

--- a/apps/web/design-sync-docs/CardContent.md
+++ b/apps/web/design-sync-docs/CardContent.md
@@ -1,0 +1,9 @@
+---
+category: Surfaces
+---
+
+# CardContent
+
+Part of the `Card` composition. The card's body region.
+
+See `Card.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CardDescription.md
+++ b/apps/web/design-sync-docs/CardDescription.md
@@ -1,0 +1,9 @@
+---
+category: Surfaces
+---
+
+# CardDescription
+
+Part of the `Card` composition. Muted supporting line under the title.
+
+See `Card.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CardFooter.md
+++ b/apps/web/design-sync-docs/CardFooter.md
@@ -1,0 +1,9 @@
+---
+category: Surfaces
+---
+
+# CardFooter
+
+Part of the `Card` composition. Bottom row, typically actions. Add `justify-end` to right-align buttons.
+
+See `Card.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CardHeader.md
+++ b/apps/web/design-sync-docs/CardHeader.md
@@ -1,0 +1,9 @@
+---
+category: Surfaces
+---
+
+# CardHeader
+
+Part of the `Card` composition. Title block at the top; stacks CardTitle over CardDescription with tight spacing. Default padding is generous — tighten with `p-4 pb-2` in dense grids.
+
+See `Card.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CardTitle.md
+++ b/apps/web/design-sync-docs/CardTitle.md
@@ -1,0 +1,9 @@
+---
+category: Surfaces
+---
+
+# CardTitle
+
+Part of the `Card` composition. The card's heading. This app styles dinner names with `font-serif` for the Young Serif display face.
+
+See `Card.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Command.md
+++ b/apps/web/design-sync-docs/Command.md
@@ -1,0 +1,27 @@
+---
+category: Navigation
+---
+
+# Command
+
+A filterable command palette / searchable list built on cmdk. Used inside
+`FancyCombobox` here, and usable on its own for quick-switchers.
+
+```jsx
+<Command>
+  <CommandInput placeholder="Search dinners…" />
+  <CommandList>
+    <CommandEmpty>No dinners found.</CommandEmpty>
+    <CommandGroup heading="This week">
+      <CommandItem>Tomato pasta</CommandItem>
+      <CommandItem>
+        Tacos
+        <CommandShortcut>⌘T</CommandShortcut>
+      </CommandItem>
+    </CommandGroup>
+  </CommandList>
+</Command>
+```
+
+Filtering is automatic from the item text. Give `Command` a border and a
+width when using it inline — on its own it is unstyled chrome.

--- a/apps/web/design-sync-docs/CommandDialog.md
+++ b/apps/web/design-sync-docs/CommandDialog.md
@@ -1,0 +1,22 @@
+---
+category: Navigation
+---
+
+# CommandDialog
+
+A `Command` palette pre-wrapped in a `Dialog` — the ⌘K pattern.
+
+```jsx
+<CommandDialog open={open} onOpenChange={setOpen}>
+  <CommandInput placeholder="Jump to…" />
+  <CommandList>
+    <CommandEmpty>Nothing matches.</CommandEmpty>
+    <CommandGroup heading="Pages">
+      <CommandItem>Dinners</CommandItem>
+      <CommandItem>This week</CommandItem>
+    </CommandGroup>
+  </CommandList>
+</CommandDialog>
+```
+
+Controlled only — wire `open` and `onOpenChange` yourself.

--- a/apps/web/design-sync-docs/CommandEmpty.md
+++ b/apps/web/design-sync-docs/CommandEmpty.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# CommandEmpty
+
+Part of the `Command` composition. Shown when the query matches nothing.
+
+See `Command.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CommandGroup.md
+++ b/apps/web/design-sync-docs/CommandGroup.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# CommandGroup
+
+Part of the `Command` composition. A titled section of items; `heading` labels it.
+
+See `Command.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CommandInput.md
+++ b/apps/web/design-sync-docs/CommandInput.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# CommandInput
+
+Part of the `Command` composition. The search field, with a magnifier icon and a bottom rule.
+
+See `Command.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CommandItem.md
+++ b/apps/web/design-sync-docs/CommandItem.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# CommandItem
+
+Part of the `Command` composition. One selectable row; highlights on keyboard or pointer selection.
+
+See `Command.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CommandList.md
+++ b/apps/web/design-sync-docs/CommandList.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# CommandList
+
+Part of the `Command` composition. Scrollable results region, capped at `max-h-[300px]`.
+
+See `Command.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CommandSeparator.md
+++ b/apps/web/design-sync-docs/CommandSeparator.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# CommandSeparator
+
+Part of the `Command` composition. A rule between groups.
+
+See `Command.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/CommandShortcut.md
+++ b/apps/web/design-sync-docs/CommandShortcut.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# CommandShortcut
+
+Part of the `Command` composition. Right-aligned muted keyboard hint inside a CommandItem.
+
+See `Command.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Dialog.md
+++ b/apps/web/design-sync-docs/Dialog.md
@@ -1,0 +1,31 @@
+---
+category: Overlays
+---
+
+# Dialog
+
+A centred modal. Use it for focused tasks on desktop; for a layout that
+adapts to mobile, prefer the app's `ResponsiveModal`, which swaps to
+`Drawer` on small screens.
+
+```jsx
+<Dialog>
+  <DialogTrigger asChild>
+    <Button>Edit dinner</Button>
+  </DialogTrigger>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Edit dinner</DialogTitle>
+      <DialogDescription>Change the name, tags or notes.</DialogDescription>
+    </DialogHeader>
+    <DinnerForm />
+    <DialogFooter>
+      <DialogClose asChild><Button variant="secondary">Cancel</Button></DialogClose>
+      <Button type="submit">Save</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+Control it with `open` + `onOpenChange`, or let the trigger manage it.
+`DialogContent` already renders the overlay, portal and close button.

--- a/apps/web/design-sync-docs/DialogClose.md
+++ b/apps/web/design-sync-docs/DialogClose.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogClose
+
+Part of the `Dialog` composition. Dismisses the dialog. Use `asChild` around a Button for a Cancel action.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DialogContent.md
+++ b/apps/web/design-sync-docs/DialogContent.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogContent
+
+Part of the `Dialog` composition. The modal panel. Renders its own overlay, portal and × close button; max-width is `lg` by default.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DialogDescription.md
+++ b/apps/web/design-sync-docs/DialogDescription.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogDescription
+
+Part of the `Dialog` composition. Muted supporting line under the title.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DialogFooter.md
+++ b/apps/web/design-sync-docs/DialogFooter.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogFooter
+
+Part of the `Dialog` composition. Action row; stacks on mobile and right-aligns from `sm` up.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DialogHeader.md
+++ b/apps/web/design-sync-docs/DialogHeader.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogHeader
+
+Part of the `Dialog` composition. Title block at the top of the panel; centred on mobile, left-aligned from `sm` up.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DialogOverlay.md
+++ b/apps/web/design-sync-docs/DialogOverlay.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogOverlay
+
+Part of the `Dialog` composition. The dimmed backdrop. `DialogContent` renders it already — placing it yourself is unusual.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DialogPortal.md
+++ b/apps/web/design-sync-docs/DialogPortal.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogPortal
+
+Part of the `Dialog` composition. Portals the dialog to the document body. Rendered by `DialogContent`.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DialogTitle.md
+++ b/apps/web/design-sync-docs/DialogTitle.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogTitle
+
+Part of the `Dialog` composition. The dialog heading. Required for accessibility.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DialogTrigger.md
+++ b/apps/web/design-sync-docs/DialogTrigger.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DialogTrigger
+
+Part of the `Dialog` composition. Opens the dialog. Use `asChild` to make your own Button the trigger.
+
+See `Dialog.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Drawer.md
+++ b/apps/web/design-sync-docs/Drawer.md
@@ -1,0 +1,28 @@
+---
+category: Overlays
+---
+
+# Drawer
+
+A bottom sheet with a drag handle, built on Vaul. This is the mobile half
+of the app's `ResponsiveModal` pattern — a `Dialog` on desktop, a `Drawer`
+below `sm`.
+
+```jsx
+<Drawer>
+  <DrawerTrigger asChild><Button>Plan dinner</Button></DrawerTrigger>
+  <DrawerContent>
+    <DrawerHeader>
+      <DrawerTitle>Plan dinner</DrawerTitle>
+      <DrawerDescription>Pick something for Tuesday.</DrawerDescription>
+    </DrawerHeader>
+    <DinnerPicker />
+    <DrawerFooter>
+      <Button>Save</Button>
+      <DrawerClose asChild><Button variant="outline">Cancel</Button></DrawerClose>
+    </DrawerFooter>
+  </DrawerContent>
+</Drawer>
+```
+
+`DrawerContent` draws its own grab handle at the top.

--- a/apps/web/design-sync-docs/DrawerClose.md
+++ b/apps/web/design-sync-docs/DrawerClose.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerClose
+
+Part of the `Drawer` composition. Dismisses the drawer.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DrawerContent.md
+++ b/apps/web/design-sync-docs/DrawerContent.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerContent
+
+Part of the `Drawer` composition. The sliding bottom panel, including the grab handle.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DrawerDescription.md
+++ b/apps/web/design-sync-docs/DrawerDescription.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerDescription
+
+Part of the `Drawer` composition. Muted supporting line under the title.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DrawerFooter.md
+++ b/apps/web/design-sync-docs/DrawerFooter.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerFooter
+
+Part of the `Drawer` composition. Action column at the bottom — buttons stack full-width.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DrawerHeader.md
+++ b/apps/web/design-sync-docs/DrawerHeader.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerHeader
+
+Part of the `Drawer` composition. Title block; text is centred on mobile.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DrawerOverlay.md
+++ b/apps/web/design-sync-docs/DrawerOverlay.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerOverlay
+
+Part of the `Drawer` composition. The dimmed backdrop, rendered by `DrawerContent`.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DrawerPortal.md
+++ b/apps/web/design-sync-docs/DrawerPortal.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerPortal
+
+Part of the `Drawer` composition. Portals the drawer to the document body, rendered by `DrawerContent`.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DrawerTitle.md
+++ b/apps/web/design-sync-docs/DrawerTitle.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerTitle
+
+Part of the `Drawer` composition. The drawer heading.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/DrawerTrigger.md
+++ b/apps/web/design-sync-docs/DrawerTrigger.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# DrawerTrigger
+
+Part of the `Drawer` composition. Opens the drawer.
+
+See `Drawer.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/FancyCombobox.md
+++ b/apps/web/design-sync-docs/FancyCombobox.md
@@ -1,0 +1,38 @@
+---
+category: Forms
+---
+
+# FancyCombobox
+
+A searchable, creatable multi-select built on `Command` — this app uses it for
+dinner tags. Unlike the other components here it is app-specific rather than a
+generic shadcn primitive.
+
+It is **fully controlled**: it holds no selection state of its own, and every
+mutation goes back to you through a callback. Options and selections are
+`{ value, label }` objects, not strings.
+
+```jsx
+<FancyCombobox
+  placeholder="Add tag…"
+  options={allTags}                      // {value,label}[] — the full vocabulary
+  selected={selectedTags}                // {value,label}[] — current selection
+  select={(option) => setSelectedTags([...selectedTags, option])}
+  unselect={(option) =>
+    setSelectedTags(selectedTags.filter((t) => t.value !== option.value))
+  }
+  removeLast={() => setSelectedTags(selectedTags.slice(0, -1))}
+  createNew={(value) => setSelectedTags([...selectedTags, { value, label: value }])}
+/>
+```
+
+- `select` / `unselect` receive the whole option object.
+- `removeLast` fires on Backspace in an empty input — the usual chip-deletion
+  gesture. It takes no argument.
+- `createNew` receives the raw typed string when the user commits a value that
+  is not already in `options`; that is what makes new tags possible.
+- Already-selected options are filtered out of the dropdown automatically.
+
+Selected values render as removable `Badge`s inside the input box. The dropdown
+opens on focus — there is no `open` prop — and its list is capped at
+`max-h-[35dvh]`, so long vocabularies scroll.

--- a/apps/web/design-sync-docs/Form.md
+++ b/apps/web/design-sync-docs/Form.md
@@ -1,0 +1,33 @@
+---
+category: Forms
+---
+
+# Form
+
+The react-hook-form binding layer. `Form` is the provider; `FormField`
+connects one field to the form state and supplies the render props.
+
+```jsx
+<Form {...form}>
+  <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+    <FormField
+      control={form.control}
+      name="name"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Household name</FormLabel>
+          <FormControl>
+            <Input placeholder="The Hollunds" {...field} />
+          </FormControl>
+          <FormDescription>Shown to everyone you invite.</FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+    <Button type="submit">Save</Button>
+  </form>
+</Form>
+```
+
+`FormMessage` renders the validation error for its field and nothing when
+the field is valid — always include it.

--- a/apps/web/design-sync-docs/FormControl.md
+++ b/apps/web/design-sync-docs/FormControl.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# FormControl
+
+Part of the `Form` composition. Wraps the actual input and wires up aria-describedby / aria-invalid. Takes exactly one child.
+
+See `Form.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/FormDescription.md
+++ b/apps/web/design-sync-docs/FormDescription.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# FormDescription
+
+Part of the `Form` composition. Muted helper text under the control.
+
+See `Form.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/FormField.md
+++ b/apps/web/design-sync-docs/FormField.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# FormField
+
+Part of the `Form` composition. Binds one field name to form state and calls `render` with `field` props to spread onto the control.
+
+See `Form.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/FormItem.md
+++ b/apps/web/design-sync-docs/FormItem.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# FormItem
+
+Part of the `Form` composition. Wraps one field's label, control, description and message, and generates the ids that link them.
+
+See `Form.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/FormLabel.md
+++ b/apps/web/design-sync-docs/FormLabel.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# FormLabel
+
+Part of the `Form` composition. The field label; turns destructive-red when the field has an error.
+
+See `Form.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/FormMessage.md
+++ b/apps/web/design-sync-docs/FormMessage.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# FormMessage
+
+Part of the `Form` composition. The validation error for the field; renders nothing when valid.
+
+See `Form.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Input.md
+++ b/apps/web/design-sync-docs/Input.md
@@ -1,0 +1,16 @@
+---
+category: Forms
+---
+
+# Input
+
+A single-line text field, `h-10` with a focus ring in the primary colour.
+
+```jsx
+<div className="space-y-2">
+  <Label htmlFor="name">Dinner name</Label>
+  <Input id="name" placeholder="Tomato pasta" />
+</div>
+```
+
+Accepts every native `<input>` prop, including `type`, `disabled` and `value`.

--- a/apps/web/design-sync-docs/Label.md
+++ b/apps/web/design-sync-docs/Label.md
@@ -1,0 +1,13 @@
+---
+category: Forms
+---
+
+# Label
+
+A form label. Pair it with a control via `htmlFor`; it dims automatically
+when the associated field is disabled.
+
+```jsx
+<Label htmlFor="slug">Household URL</Label>
+<Input id="slug" />
+```

--- a/apps/web/design-sync-docs/Select.md
+++ b/apps/web/design-sync-docs/Select.md
@@ -1,0 +1,26 @@
+---
+category: Forms
+---
+
+# Select
+
+A dropdown built on Radix Select. `Select` is the stateful root; the
+trigger shows the current value and the content holds the options.
+
+```jsx
+<Select defaultValue="dinner">
+  <SelectTrigger className="w-48">
+    <SelectValue placeholder="Pick a meal" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectGroup>
+      <SelectLabel>Meals</SelectLabel>
+      <SelectItem value="breakfast">Breakfast</SelectItem>
+      <SelectItem value="dinner">Dinner</SelectItem>
+    </SelectGroup>
+  </SelectContent>
+</Select>
+```
+
+Use `defaultValue` for an uncontrolled select, or `value` + `onValueChange`
+to control it. The trigger has no width of its own — set one.

--- a/apps/web/design-sync-docs/SelectContent.md
+++ b/apps/web/design-sync-docs/SelectContent.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectContent
+
+Part of the `Select` composition. The popover panel holding the options.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SelectGroup.md
+++ b/apps/web/design-sync-docs/SelectGroup.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectGroup
+
+Part of the `Select` composition. Groups related items under a SelectLabel.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SelectItem.md
+++ b/apps/web/design-sync-docs/SelectItem.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectItem
+
+Part of the `Select` composition. One option. Requires a `value`; shows a check when selected.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SelectLabel.md
+++ b/apps/web/design-sync-docs/SelectLabel.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectLabel
+
+Part of the `Select` composition. A non-selectable heading for a SelectGroup.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SelectScrollDownButton.md
+++ b/apps/web/design-sync-docs/SelectScrollDownButton.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectScrollDownButton
+
+Part of the `Select` composition. Appears automatically when a long list overflows; you rarely place it yourself.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SelectScrollUpButton.md
+++ b/apps/web/design-sync-docs/SelectScrollUpButton.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectScrollUpButton
+
+Part of the `Select` composition. Appears automatically when a long list is scrolled; you rarely place it yourself.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SelectSeparator.md
+++ b/apps/web/design-sync-docs/SelectSeparator.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectSeparator
+
+Part of the `Select` composition. A rule between option groups.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SelectTrigger.md
+++ b/apps/web/design-sync-docs/SelectTrigger.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectTrigger
+
+Part of the `Select` composition. The closed-state button. Give it an explicit width.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SelectValue.md
+++ b/apps/web/design-sync-docs/SelectValue.md
@@ -1,0 +1,9 @@
+---
+category: Forms
+---
+
+# SelectValue
+
+Part of the `Select` composition. Renders the selected option's label, or `placeholder` when nothing is chosen.
+
+See `Select.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Separator.md
+++ b/apps/web/design-sync-docs/Separator.md
@@ -1,0 +1,14 @@
+---
+category: Layout
+---
+
+# Separator
+
+A hairline rule in the `--border` colour.
+
+```jsx
+<Separator className="my-4" />
+<Separator orientation="vertical" className="h-6" />
+```
+
+A vertical separator has no intrinsic height — always give it one.

--- a/apps/web/design-sync-docs/Sheet.md
+++ b/apps/web/design-sync-docs/Sheet.md
@@ -1,0 +1,26 @@
+---
+category: Overlays
+---
+
+# Sheet
+
+A panel that slides in from an edge — good for filters, detail views and
+secondary navigation.
+
+```jsx
+<Sheet>
+  <SheetTrigger asChild><Button variant="outline">Filters</Button></SheetTrigger>
+  <SheetContent side="right">
+    <SheetHeader>
+      <SheetTitle>Filter dinners</SheetTitle>
+      <SheetDescription>Narrow the list by tag.</SheetDescription>
+    </SheetHeader>
+    <FilterControls />
+    <SheetFooter>
+      <Button>Apply</Button>
+    </SheetFooter>
+  </SheetContent>
+</Sheet>
+```
+
+`side` on `SheetContent`: `right` (default) · `left` · `top` · `bottom`.

--- a/apps/web/design-sync-docs/SheetClose.md
+++ b/apps/web/design-sync-docs/SheetClose.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetClose
+
+Part of the `Sheet` composition. Dismisses the sheet.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SheetContent.md
+++ b/apps/web/design-sync-docs/SheetContent.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetContent
+
+Part of the `Sheet` composition. The sliding panel. `side` picks the edge it enters from; left/right panels are 3/4 width on mobile and capped at `sm` on desktop.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SheetDescription.md
+++ b/apps/web/design-sync-docs/SheetDescription.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetDescription
+
+Part of the `Sheet` composition. Muted supporting line under the title.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SheetFooter.md
+++ b/apps/web/design-sync-docs/SheetFooter.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetFooter
+
+Part of the `Sheet` composition. Action row pinned below the content; stacks on mobile.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SheetHeader.md
+++ b/apps/web/design-sync-docs/SheetHeader.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetHeader
+
+Part of the `Sheet` composition. Title block at the top of the panel.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SheetOverlay.md
+++ b/apps/web/design-sync-docs/SheetOverlay.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetOverlay
+
+Part of the `Sheet` composition. The dimmed backdrop, rendered by `SheetContent`.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SheetPortal.md
+++ b/apps/web/design-sync-docs/SheetPortal.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetPortal
+
+Part of the `Sheet` composition. Portals the sheet to the document body, rendered by `SheetContent`.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SheetTitle.md
+++ b/apps/web/design-sync-docs/SheetTitle.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetTitle
+
+Part of the `Sheet` composition. The sheet heading.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SheetTrigger.md
+++ b/apps/web/design-sync-docs/SheetTrigger.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# SheetTrigger
+
+Part of the `Sheet` composition. Opens the sheet; use `asChild` to wrap your own control.
+
+See `Sheet.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Sidebar.md
+++ b/apps/web/design-sync-docs/Sidebar.md
@@ -1,0 +1,52 @@
+---
+category: Navigation
+---
+
+# Sidebar
+
+The app's collapsible navigation rail. Everything in this family must sit
+inside a `SidebarProvider`, which owns the open/collapsed state and the
+keyboard shortcut — without it the parts render unstyled or throw.
+
+```jsx
+<SidebarProvider>
+  <Sidebar>
+    <SidebarHeader>PlanEatRepeat</SidebarHeader>
+    <SidebarContent>
+      <SidebarGroup>
+        <SidebarGroupLabel>Plan</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton isActive>
+                <CalendarDays />
+                <span>This week</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton>
+                <UtensilsCrossed />
+                <span>Dinners</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    </SidebarContent>
+    <SidebarFooter>
+      <UserAvatar />
+    </SidebarFooter>
+  </Sidebar>
+  <SidebarInset>
+    <SidebarTrigger />
+    <PageContent />
+  </SidebarInset>
+</SidebarProvider>
+```
+
+`Sidebar` props: `side` (`left`/`right`), `variant`
+(`sidebar`/`floating`/`inset`), `collapsible`
+(`offcanvas`/`icon`/`none`). The sidebar has its own colour tokens —
+`bg-sidebar`, `text-sidebar-foreground`, `border-sidebar-border` — which
+are warmer than the page surface; use those inside it rather than the
+regular `bg-background` family.

--- a/apps/web/design-sync-docs/SidebarContent.md
+++ b/apps/web/design-sync-docs/SidebarContent.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarContent
+
+Part of the `Sidebar` composition. The scrollable middle region between header and footer.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarFooter.md
+++ b/apps/web/design-sync-docs/SidebarFooter.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarFooter
+
+Part of the `Sidebar` composition. Bottom block — usually the account row.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarGroup.md
+++ b/apps/web/design-sync-docs/SidebarGroup.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarGroup
+
+Part of the `Sidebar` composition. A titled section of the nav.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarGroupAction.md
+++ b/apps/web/design-sync-docs/SidebarGroupAction.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarGroupAction
+
+Part of the `Sidebar` composition. A small icon button in a group's top-right corner, e.g. add.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarGroupContent.md
+++ b/apps/web/design-sync-docs/SidebarGroupContent.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarGroupContent
+
+Part of the `Sidebar` composition. Wrapper for a group's menu.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarGroupLabel.md
+++ b/apps/web/design-sync-docs/SidebarGroupLabel.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarGroupLabel
+
+Part of the `Sidebar` composition. Small uppercase heading for a group; fades out when the sidebar collapses to icons.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarHeader.md
+++ b/apps/web/design-sync-docs/SidebarHeader.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarHeader
+
+Part of the `Sidebar` composition. Top block — branding or a household switcher.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarInput.md
+++ b/apps/web/design-sync-docs/SidebarInput.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarInput
+
+Part of the `Sidebar` composition. An Input styled for the sidebar surface.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarInset.md
+++ b/apps/web/design-sync-docs/SidebarInset.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarInset
+
+Part of the `Sidebar` composition. The main content area beside the sidebar. Wrap the page body in it so margins track the sidebar's state.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenu.md
+++ b/apps/web/design-sync-docs/SidebarMenu.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenu
+
+Part of the `Sidebar` composition. The `ul` holding menu items.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenuAction.md
+++ b/apps/web/design-sync-docs/SidebarMenuAction.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenuAction
+
+Part of the `Sidebar` composition. A secondary icon button pinned to the right of a menu row.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenuBadge.md
+++ b/apps/web/design-sync-docs/SidebarMenuBadge.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenuBadge
+
+Part of the `Sidebar` composition. A count pinned to the right of a menu row.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenuButton.md
+++ b/apps/web/design-sync-docs/SidebarMenuButton.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenuButton
+
+Part of the `Sidebar` composition. The clickable nav row. `isActive` marks the current page; `asChild` lets a `next/link` be the row. Give it an icon plus a `<span>` label so it collapses to icon-only cleanly.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenuItem.md
+++ b/apps/web/design-sync-docs/SidebarMenuItem.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenuItem
+
+Part of the `Sidebar` composition. One `li` in the menu; wraps a SidebarMenuButton.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenuSkeleton.md
+++ b/apps/web/design-sync-docs/SidebarMenuSkeleton.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenuSkeleton
+
+Part of the `Sidebar` composition. Loading placeholder shaped like a menu row.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenuSub.md
+++ b/apps/web/design-sync-docs/SidebarMenuSub.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenuSub
+
+Part of the `Sidebar` composition. Nested list for a row's children, indented with a left rule.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenuSubButton.md
+++ b/apps/web/design-sync-docs/SidebarMenuSubButton.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenuSubButton
+
+Part of the `Sidebar` composition. The clickable row inside a SidebarMenuSub; `size` is `sm` or `md`.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarMenuSubItem.md
+++ b/apps/web/design-sync-docs/SidebarMenuSubItem.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarMenuSubItem
+
+Part of the `Sidebar` composition. One `li` in a SidebarMenuSub.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarProvider.md
+++ b/apps/web/design-sync-docs/SidebarProvider.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarProvider
+
+Part of the `Sidebar` composition. Owns open/collapsed state, mobile detection and the ⌘B shortcut. Every other Sidebar part requires it as an ancestor.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarRail.md
+++ b/apps/web/design-sync-docs/SidebarRail.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarRail
+
+Part of the `Sidebar` composition. The thin draggable edge that toggles the sidebar.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarSeparator.md
+++ b/apps/web/design-sync-docs/SidebarSeparator.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarSeparator
+
+Part of the `Sidebar` composition. A rule in the sidebar's own border colour.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/SidebarTrigger.md
+++ b/apps/web/design-sync-docs/SidebarTrigger.md
@@ -1,0 +1,9 @@
+---
+category: Navigation
+---
+
+# SidebarTrigger
+
+Part of the `Sidebar` composition. The hamburger button that opens or collapses the sidebar. Place it in your page header, inside SidebarInset.
+
+See `Sidebar.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Skeleton.md
+++ b/apps/web/design-sync-docs/Skeleton.md
@@ -1,0 +1,15 @@
+---
+category: Feedback
+---
+
+# Skeleton
+
+A pulsing placeholder block for content that has not loaded yet. It has no
+size of its own — the className is the shape.
+
+```jsx
+<div className="space-y-2">
+  <Skeleton className="h-5 w-40" />
+  <Skeleton className="h-24 w-full rounded-lg" />
+</div>
+```

--- a/apps/web/design-sync-docs/Textarea.md
+++ b/apps/web/design-sync-docs/Textarea.md
@@ -1,0 +1,14 @@
+---
+category: Forms
+---
+
+# Textarea
+
+A multi-line text field. Same border, radius and focus treatment as `Input`.
+
+```jsx
+<div className="space-y-2">
+  <Label htmlFor="notes">Notes</Label>
+  <Textarea id="notes" rows={4} placeholder="Anything worth remembering…" />
+</div>
+```

--- a/apps/web/design-sync-docs/Toast.md
+++ b/apps/web/design-sync-docs/Toast.md
@@ -1,0 +1,21 @@
+---
+category: Feedback
+---
+
+# Toast
+
+A single notification. In normal use you do not render this directly —
+call `toast()` and let `Toaster` render it. Render it manually only when
+you need a static, always-visible notification in a mockup.
+
+```jsx
+<Toast>
+  <div className="grid gap-1">
+    <ToastTitle>Dinner saved</ToastTitle>
+    <ToastDescription>Added to this week's plan.</ToastDescription>
+  </div>
+  <ToastClose />
+</Toast>
+```
+
+`variant`: `default` · `destructive`.

--- a/apps/web/design-sync-docs/ToastAction.md
+++ b/apps/web/design-sync-docs/ToastAction.md
@@ -1,0 +1,9 @@
+---
+category: Feedback
+---
+
+# ToastAction
+
+Part of the `Toast` composition. An inline action button, e.g. Undo. Requires an `altText` prop for screen readers.
+
+See `Toast.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/ToastClose.md
+++ b/apps/web/design-sync-docs/ToastClose.md
@@ -1,0 +1,9 @@
+---
+category: Feedback
+---
+
+# ToastClose
+
+Part of the `Toast` composition. The × dismiss control; appears on hover.
+
+See `Toast.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/ToastDescription.md
+++ b/apps/web/design-sync-docs/ToastDescription.md
@@ -1,0 +1,9 @@
+---
+category: Feedback
+---
+
+# ToastDescription
+
+Part of the `Toast` composition. Secondary line, 90% opacity.
+
+See `Toast.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/ToastProvider.md
+++ b/apps/web/design-sync-docs/ToastProvider.md
@@ -1,0 +1,9 @@
+---
+category: Feedback
+---
+
+# ToastProvider
+
+Part of the `Toaster` composition. Radix context provider. `Toaster` already renders it — you do not need it separately.
+
+See `Toaster.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/ToastTitle.md
+++ b/apps/web/design-sync-docs/ToastTitle.md
@@ -1,0 +1,9 @@
+---
+category: Feedback
+---
+
+# ToastTitle
+
+Part of the `Toast` composition. Bold first line of the notification.
+
+See `Toast.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/ToastViewport.md
+++ b/apps/web/design-sync-docs/ToastViewport.md
@@ -1,0 +1,9 @@
+---
+category: Feedback
+---
+
+# ToastViewport
+
+Part of the `Toaster` composition. The fixed region toasts stack into: bottom-right on desktop, top on mobile.
+
+See `Toaster.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/Toaster.md
+++ b/apps/web/design-sync-docs/Toaster.md
@@ -1,0 +1,22 @@
+---
+category: Feedback
+---
+
+# Toaster
+
+Mounts the toast viewport. Render it once near the root of the app; every
+`toast()` call then renders through it. Takes no props.
+
+```jsx
+<>
+  <AppContent />
+  <Toaster />
+</>
+```
+
+Trigger toasts imperatively rather than rendering `Toast` yourself:
+
+```jsx
+toast({ title: "Dinner saved", description: "Added to this week's plan." })
+toast({ title: "Could not save", variant: "destructive" })
+```

--- a/apps/web/design-sync-docs/Tooltip.md
+++ b/apps/web/design-sync-docs/Tooltip.md
@@ -1,0 +1,21 @@
+---
+category: Overlays
+---
+
+# Tooltip
+
+A hover/focus label. Every tooltip must sit inside a `TooltipProvider` —
+mount one high in the tree rather than per tooltip.
+
+```jsx
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button variant="ghost" size="icon"><Info className="h-4 w-4" /></Button>
+    </TooltipTrigger>
+    <TooltipContent>Dinners you have not cooked recently</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
+Tooltips are hover-only — never put an action or essential text in one.

--- a/apps/web/design-sync-docs/TooltipContent.md
+++ b/apps/web/design-sync-docs/TooltipContent.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# TooltipContent
+
+Part of the `Tooltip` composition. The floating label. `side` and `sideOffset` position it.
+
+See `Tooltip.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/TooltipProvider.md
+++ b/apps/web/design-sync-docs/TooltipProvider.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# TooltipProvider
+
+Part of the `Tooltip` composition. Required context and shared open/close timing. Mount once near the app root.
+
+See `Tooltip.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-docs/TooltipTrigger.md
+++ b/apps/web/design-sync-docs/TooltipTrigger.md
@@ -1,0 +1,9 @@
+---
+category: Overlays
+---
+
+# TooltipTrigger
+
+Part of the `Tooltip` composition. The element that reveals the tooltip. Use `asChild` so the trigger is your real control.
+
+See `Tooltip.prompt.md` for the full composition example — these parts are not used standalone.

--- a/apps/web/design-sync-styles/build.sh
+++ b/apps/web/design-sync-styles/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Compiles the static stylesheet that ships with the design-system upload.
+# Run from the repo root before the design-sync converter.
+set -e
+here="$(cd "$(dirname "$0")" && pwd)"
+node "$here/gen-candidates.mjs"
+npx tailwindcss -c "$here/tailwind.config.cjs" -i "$here/input.css" -o "$here/ds.css" --minify

--- a/apps/web/design-sync-styles/gen-candidates.mjs
+++ b/apps/web/design-sync-styles/gen-candidates.mjs
@@ -1,0 +1,214 @@
+// Emits candidates.txt — a class-name corpus that Tailwind's JIT scans as
+// "content", so the compiled design-system stylesheet carries a usable utility
+// surface even for markup that does not exist yet (designs the Claude Design
+// agent writes later).
+//
+// Two jobs, only one of which the repo's own source can do:
+//   1. Classes the DS components themselves use     -> covered by the src glob.
+//   2. Classes a design agent will reach for later  -> covered by this file.
+//
+// Keep it broad but curated: every entry costs bytes in the shipped stylesheet.
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const push = (target, ...xs) => target.push(...xs.flat(Infinity).filter(Boolean));
+const cross = (prefixes, names) =>
+  prefixes.flatMap((p) => names.map((n) => `${p}${n}`));
+
+// ── scales ────────────────────────────────────────────────────────────────
+const SPACE = ["0", "px", "0.5", "1", "1.5", "2", "2.5", "3", "3.5", "4", "5",
+  "6", "7", "8", "9", "10", "11", "12", "14", "16", "20", "24", "28", "32",
+  "36", "40", "44", "48", "52", "56", "60", "64", "72", "80", "96"];
+const FRACTIONS = ["1/2", "1/3", "2/3", "1/4", "2/4", "3/4", "1/5", "2/5",
+  "3/5", "4/5", "1/6", "5/6", "1/12", "5/12", "7/12", "11/12"];
+const SIZE_KEYWORDS = ["auto", "full", "screen", "min", "max", "fit", "px"];
+const MAXW = ["none", "0", "xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl",
+  "5xl", "6xl", "7xl", "full", "min", "max", "fit", "prose", "screen-sm",
+  "screen-md", "screen-lg", "screen-xl", "screen-2xl"];
+
+const SEMANTIC = ["background", "foreground", "card", "card-foreground",
+  "popover", "popover-foreground", "primary", "primary-foreground",
+  "secondary", "secondary-foreground", "muted", "muted-foreground",
+  "accent", "accent-foreground", "destructive", "destructive-foreground",
+  "border", "input", "ring", "sidebar", "sidebar-foreground",
+  "sidebar-primary", "sidebar-primary-foreground", "sidebar-accent",
+  "sidebar-accent-foreground", "sidebar-border", "sidebar-ring"];
+const BASE_COLORS = ["white", "black", "transparent", "current", "inherit"];
+// Raw palettes are an escape hatch, not the vocabulary — the warm-stone theme
+// is expressed through SEMANTIC. Kept narrow on purpose: every extra palette
+// multiplies across prefixes and state variants.
+const PALETTES = ["stone", "neutral", "gray", "slate", "red", "orange", "amber",
+  "green", "emerald", "sky", "blue", "rose"];
+const STEPS = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+const RAW_COLORS = PALETTES.flatMap((p) => STEPS.map((s) => `${p}-${s}`));
+const OPACITIES = ["5", "10", "20", "50", "80", "90"];
+
+// ── layout ────────────────────────────────────────────────────────────────
+const LAYOUT = [];
+push(LAYOUT, ["block", "inline-block", "inline", "flex", "inline-flex", "grid",
+  "inline-grid", "table", "table-cell", "table-row", "contents", "hidden",
+  "flow-root", "list-item"]);
+push(LAYOUT, ["flex-row", "flex-row-reverse", "flex-col", "flex-col-reverse",
+  "flex-wrap", "flex-wrap-reverse", "flex-nowrap", "flex-1", "flex-auto",
+  "flex-initial", "flex-none", "grow", "grow-0", "shrink", "shrink-0",
+  "basis-0", "basis-auto", "basis-full", "basis-1/2", "basis-1/3", "basis-1/4"]);
+push(LAYOUT, cross(["items-"], ["start", "end", "center", "baseline", "stretch"]));
+push(LAYOUT, cross(["justify-"], ["start", "end", "center", "between", "around", "evenly", "stretch"]));
+push(LAYOUT, cross(["content-"], ["start", "end", "center", "between", "around", "evenly", "stretch"]));
+push(LAYOUT, cross(["self-"], ["auto", "start", "end", "center", "stretch", "baseline"]));
+push(LAYOUT, cross(["place-items-", "place-content-", "place-self-"], ["start", "end", "center", "stretch"]));
+push(LAYOUT, cross(["grid-cols-"], ["none", "subgrid", ...Array.from({ length: 12 }, (_, i) => `${i + 1}`)]));
+push(LAYOUT, cross(["grid-rows-"], ["none", ...Array.from({ length: 6 }, (_, i) => `${i + 1}`)]));
+push(LAYOUT, cross(["col-span-"], ["full", ...Array.from({ length: 12 }, (_, i) => `${i + 1}`)]));
+push(LAYOUT, cross(["row-span-"], ["full", ...Array.from({ length: 6 }, (_, i) => `${i + 1}`)]));
+push(LAYOUT, cross(["col-start-", "col-end-"], Array.from({ length: 13 }, (_, i) => `${i + 1}`)));
+push(LAYOUT, cross(["auto-cols-", "auto-rows-"], ["auto", "min", "max", "fr"]));
+push(LAYOUT, ["grid-flow-row", "grid-flow-col", "grid-flow-dense"]);
+push(LAYOUT, cross(["order-"], ["first", "last", "none", ...Array.from({ length: 12 }, (_, i) => `${i + 1}`)]));
+push(LAYOUT, ["static", "relative", "absolute", "fixed", "sticky", "isolate"]);
+push(LAYOUT, cross(["z-"], ["auto", "0", "10", "20", "30", "40", "50"]));
+push(LAYOUT, cross(["inset-", "inset-x-", "inset-y-", "top-", "right-", "bottom-", "left-"],
+  ["auto", "full", "1/2", ...SPACE]));
+push(LAYOUT, cross(["-inset-", "-top-", "-right-", "-bottom-", "-left-"], ["1", "2", "3", "4", "px", "full"]));
+push(LAYOUT, cross(["overflow-", "overflow-x-", "overflow-y-"],
+  ["auto", "hidden", "clip", "visible", "scroll"]));
+push(LAYOUT, ["float-left", "float-right", "float-none", "clear-both", "clear-none"]);
+push(LAYOUT, cross(["object-"], ["contain", "cover", "fill", "none", "scale-down",
+  "center", "top", "bottom", "left", "right"]));
+push(LAYOUT, cross(["aspect-"], ["auto", "square", "video"]));
+
+// ── spacing ───────────────────────────────────────────────────────────────
+const SPACING = [];
+push(SPACING, cross(["p-", "px-", "py-", "pt-", "pr-", "pb-", "pl-", "ps-", "pe-"], SPACE));
+push(SPACING, cross(["m-", "mx-", "my-", "mt-", "mr-", "mb-", "ml-", "ms-", "me-"], [...SPACE, "auto"]));
+push(SPACING, cross(["-m-", "-mx-", "-my-", "-mt-", "-mr-", "-mb-", "-ml-"], SPACE.slice(1, 20)));
+push(SPACING, cross(["gap-", "gap-x-", "gap-y-"], SPACE));
+push(SPACING, cross(["space-x-", "space-y-"], [...SPACE.slice(0, 22), "reverse"]));
+
+// ── sizing ────────────────────────────────────────────────────────────────
+const SIZING = [];
+push(SIZING, cross(["w-"], [...SPACE, ...FRACTIONS, ...SIZE_KEYWORDS]));
+push(SIZING, cross(["h-"], [...SPACE, ...FRACTIONS, ...SIZE_KEYWORDS, "svh", "dvh", "lvh"]));
+push(SIZING, cross(["size-"], [...SPACE, "full", "fit", "auto"]));
+push(SIZING, cross(["min-w-", "min-h-"], [...SPACE.slice(0, 20), "0", "full", "min", "max", "fit", "screen", "svh", "dvh"]));
+push(SIZING, cross(["max-w-"], MAXW));
+push(SIZING, cross(["max-h-"], [...SPACE.slice(0, 24), "none", "full", "screen", "min", "max", "fit", "svh", "dvh"]));
+
+// ── typography ────────────────────────────────────────────────────────────
+const TYPO = [];
+push(TYPO, cross(["text-"], ["xs", "sm", "base", "lg", "xl", "2xl", "3xl", "4xl",
+  "5xl", "6xl", "7xl", "8xl", "9xl"]));
+push(TYPO, cross(["font-"], ["thin", "extralight", "light", "normal", "medium",
+  "semibold", "bold", "extrabold", "black", "sans", "serif", "mono"]));
+push(TYPO, cross(["leading-"], ["none", "tight", "snug", "normal", "relaxed",
+  "loose", "3", "4", "5", "6", "7", "8", "9", "10"]));
+push(TYPO, cross(["tracking-"], ["tighter", "tight", "normal", "wide", "wider", "widest"]));
+push(TYPO, cross(["text-"], ["left", "center", "right", "justify", "start", "end",
+  "balance", "pretty", "wrap", "nowrap", "ellipsis", "clip"]));
+push(TYPO, ["uppercase", "lowercase", "capitalize", "normal-case", "italic",
+  "not-italic", "underline", "overline", "line-through", "no-underline",
+  "truncate", "antialiased", "subpixel-antialiased", "tabular-nums",
+  "slashed-zero", "align-top", "align-middle", "align-bottom", "align-baseline"]);
+push(TYPO, cross(["line-clamp-"], ["none", "1", "2", "3", "4", "5", "6"]));
+push(TYPO, cross(["whitespace-"], ["normal", "nowrap", "pre", "pre-line", "pre-wrap", "break-spaces"]));
+push(TYPO, ["break-normal", "break-words", "break-all", "break-keep",
+  "list-none", "list-disc", "list-decimal", "list-inside", "list-outside",
+  "underline-offset-2", "underline-offset-4", "underline-offset-8",
+  "decoration-2", "indent-4", "indent-8"]);
+push(TYPO, cross(["columns-"], ["1", "2", "3", "4", "auto"]));
+
+// ── color ─────────────────────────────────────────────────────────────────
+const COLOR = [];
+// The on-brand palette gets every colour-bearing prefix...
+push(COLOR, cross(["bg-", "text-", "border-", "ring-", "fill-", "stroke-",
+  "decoration-", "outline-", "divide-", "placeholder-", "accent-",
+  "caret-", "shadow-", "from-", "via-", "to-"], [...SEMANTIC, ...BASE_COLORS]));
+// ...the raw escape-hatch palettes only the prefixes that actually get reached for.
+push(COLOR, cross(["bg-", "text-", "border-", "fill-"], RAW_COLORS));
+// Opacity modifiers, semantic palette only (the on-brand vocabulary).
+push(COLOR, cross(["bg-", "text-", "border-", "ring-"],
+  SEMANTIC.flatMap((c) => OPACITIES.map((o) => `${c}/${o}`))));
+push(COLOR, cross(["opacity-"], ["0", "5", "10", "20", "25", "30", "40", "50",
+  "60", "70", "75", "80", "90", "95", "100"]));
+push(COLOR, ["bg-gradient-to-r", "bg-gradient-to-l", "bg-gradient-to-t",
+  "bg-gradient-to-b", "bg-gradient-to-br", "bg-gradient-to-tr", "bg-none",
+  "bg-cover", "bg-contain", "bg-center", "bg-no-repeat", "bg-clip-text",
+  "bg-clip-border", "bg-fixed"]);
+
+// ── borders & effects ─────────────────────────────────────────────────────
+const EFFECTS = [];
+push(EFFECTS, cross(["rounded", "rounded-t", "rounded-r", "rounded-b", "rounded-l",
+  "rounded-tl", "rounded-tr", "rounded-br", "rounded-bl"],
+  ["", "-none", "-sm", "-md", "-lg", "-xl", "-2xl", "-3xl", "-full"]));
+push(EFFECTS, cross(["border", "border-t", "border-r", "border-b", "border-l",
+  "border-x", "border-y"], ["", "-0", "-2", "-4", "-8"]));
+push(EFFECTS, ["border-solid", "border-dashed", "border-dotted", "border-double",
+  "border-none", "divide-x", "divide-y", "divide-x-0", "divide-y-0",
+  "divide-solid", "divide-dashed"]);
+push(EFFECTS, cross(["shadow"], ["", "-sm", "-md", "-lg", "-xl", "-2xl", "-inner", "-none"]));
+push(EFFECTS, cross(["ring", "ring-offset"], ["", "-0", "-1", "-2", "-4", "-8"]));
+push(EFFECTS, ["ring-inset", "outline-none", "outline", "outline-1", "outline-2",
+  "outline-offset-2", "outline-dashed"]);
+push(EFFECTS, cross(["blur", "backdrop-blur"], ["", "-none", "-sm", "-md", "-lg", "-xl", "-2xl", "-3xl"]));
+push(EFFECTS, cross(["brightness-", "contrast-", "saturate-"], ["0", "50", "75", "90", "100", "110", "125", "150", "200"]));
+push(EFFECTS, ["grayscale", "grayscale-0", "invert", "invert-0", "sepia", "sepia-0",
+  "mix-blend-multiply", "mix-blend-overlay", "bg-blend-multiply"]);
+
+// ── transform, transition, interactivity ─────────────────────────────────
+const MOTION = [];
+push(MOTION, cross(["scale-", "scale-x-", "scale-y-"], ["0", "50", "75", "90", "95", "100", "105", "110", "125", "150"]));
+push(MOTION, cross(["rotate-", "-rotate-"], ["0", "1", "2", "3", "6", "12", "45", "90", "180"]));
+push(MOTION, cross(["translate-x-", "translate-y-", "-translate-x-", "-translate-y-"],
+  [...SPACE.slice(0, 22), "full", "1/2"]));
+push(MOTION, cross(["skew-x-", "skew-y-"], ["0", "1", "2", "3", "6", "12"]));
+push(MOTION, cross(["origin-"], ["center", "top", "top-right", "right", "bottom-right",
+  "bottom", "bottom-left", "left", "top-left"]));
+push(MOTION, ["transform", "transform-gpu", "transform-none"]);
+push(MOTION, cross(["transition"], ["", "-none", "-all", "-colors", "-opacity", "-shadow", "-transform"]));
+push(MOTION, cross(["duration-", "delay-"], ["0", "75", "100", "150", "200", "300", "500", "700", "1000"]));
+push(MOTION, cross(["ease-"], ["linear", "in", "out", "in-out"]));
+push(MOTION, cross(["animate-"], ["none", "spin", "ping", "pulse", "bounce"]));
+push(MOTION, cross(["cursor-"], ["auto", "default", "pointer", "wait", "text", "move",
+  "help", "not-allowed", "grab", "grabbing"]));
+push(MOTION, cross(["select-"], ["none", "text", "all", "auto"]));
+push(MOTION, ["pointer-events-none", "pointer-events-auto", "resize", "resize-none",
+  "resize-y", "appearance-none", "sr-only", "not-sr-only", "will-change-transform",
+  "scroll-smooth", "snap-x", "snap-y", "snap-center", "snap-start", "touch-none"]);
+
+// ── assemble, then add variants where they earn their bytes ───────────────
+const BASE = [...LAYOUT, ...SPACING, ...SIZING, ...TYPO, ...COLOR, ...EFFECTS, ...MOTION];
+
+// Responsive: structural utilities only. A design agent varies layout, spacing,
+// sizing and type scale across breakpoints; it rarely re-colors at `lg:`.
+const RESPONSIVE_SUBJECT = [...LAYOUT, ...SPACING, ...SIZING, ...TYPO];
+const RESPONSIVE = cross(["sm:", "md:", "lg:", "xl:"], RESPONSIVE_SUBJECT);
+
+// Interactive states. Restricted to the utilities that genuinely differ per
+// state — colour, ring, shadow, opacity, transform — rather than all of COLOR,
+// which would multiply the sheet past any reasonable size.
+const STATE_SUBJECT = [
+  ...cross(["bg-", "text-", "border-", "ring-"], [...SEMANTIC, ...BASE_COLORS]),
+  ...cross(["bg-", "text-", "border-"], RAW_COLORS),
+  ...cross(["bg-", "text-", "border-"],
+    SEMANTIC.flatMap((c) => OPACITIES.map((o) => `${c}/${o}`))),
+  ...cross(["opacity-"], ["0", "20", "50", "70", "80", "90", "100"]),
+  ...cross(["shadow"], ["", "-sm", "-md", "-lg", "-xl", "-none"]),
+  ...cross(["ring", "ring-offset"], ["", "-0", "-1", "-2", "-4"]),
+  ...cross(["scale-"], ["95", "100", "105", "110"]),
+  ...cross(["translate-y-", "-translate-y-"], ["0", "0.5", "1", "2"]),
+  "underline", "no-underline", "cursor-not-allowed", "outline-none",
+];
+const STATES = cross(["hover:", "focus:", "focus-visible:", "active:",
+  "disabled:", "group-hover:", "dark:"], STATE_SUBJECT);
+
+// A few structural state utilities that do come up (hidden on hover, etc.).
+const STATE_LAYOUT = cross(["hover:", "focus:", "disabled:", "group-hover:", "dark:"],
+  ["hidden", "block", "flex", "underline", "no-underline", "opacity-0",
+   "opacity-50", "opacity-100", "pointer-events-none", "cursor-not-allowed"]);
+
+const all = [...new Set([...BASE, ...RESPONSIVE, ...STATES, ...STATE_LAYOUT])].sort();
+
+const here = dirname(fileURLToPath(import.meta.url));
+writeFileSync(join(here, "candidates.txt"), all.join("\n") + "\n");
+console.error(`candidates: ${all.length}`);

--- a/apps/web/design-sync-styles/input.css
+++ b/apps/web/design-sync-styles/input.css
@@ -1,0 +1,104 @@
+@import url("https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&family=Young+Serif&display=swap");
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    /* Brand typefaces. In the Next.js app these are injected by next/font;
+       here they are bound to the same families loaded above. */
+    --font-quicksand: "Quicksand";
+    --font-young-serif: "Young Serif";
+
+    /* Warm Stone Theme */
+    --background: 40 20% 97%;
+    --foreground: 24 10% 10%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 24 10% 10%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 24 10% 10%;
+
+    /* Terracotta/Orange Primary */
+    --primary: 18 75% 55%;
+    --primary-foreground: 60 9% 98%;
+
+    --secondary: 40 20% 94%;
+    --secondary-foreground: 24 10% 10%;
+
+    --muted: 40 20% 94%;
+    --muted-foreground: 25 5% 45%;
+
+    --accent: 40 20% 90%;
+    --accent-foreground: 24 10% 10%;
+
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 60 9% 98%;
+
+    --border: 40 15% 88%;
+    --input: 40 15% 88%;
+    --ring: 18 75% 55%;
+
+    --radius: 0.75rem;
+
+    /* Sidebar colors matching the warm theme */
+    --sidebar-background: 40 20% 95%;
+    --sidebar-foreground: 24 10% 26%;
+    --sidebar-primary: 18 75% 55%;
+    --sidebar-primary-foreground: 60 9% 98%;
+    --sidebar-accent: 40 20% 90%;
+    --sidebar-accent-foreground: 24 10% 10%;
+    --sidebar-border: 40 15% 88%;
+    --sidebar-ring: 18 75% 55%;
+  }
+
+  .dark {
+    --background: 24 10% 10%;
+    --foreground: 40 20% 97%;
+
+    --card: 24 10% 12%;
+    --card-foreground: 40 20% 97%;
+
+    --popover: 24 10% 12%;
+    --popover-foreground: 40 20% 97%;
+
+    --primary: 18 75% 55%;
+    --primary-foreground: 60 9% 98%;
+
+    --secondary: 24 10% 16%;
+    --secondary-foreground: 40 20% 97%;
+
+    --muted: 24 10% 16%;
+    --muted-foreground: 40 10% 65%;
+
+    --accent: 24 10% 16%;
+    --accent-foreground: 40 20% 97%;
+
+    --destructive: 0 62% 30%;
+    --destructive-foreground: 40 20% 97%;
+
+    --border: 24 10% 16%;
+    --input: 24 10% 16%;
+    --ring: 18 75% 55%;
+
+    --sidebar-background: 24 10% 12%;
+    --sidebar-foreground: 40 10% 70%;
+    --sidebar-primary: 18 75% 55%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 24 10% 16%;
+    --sidebar-accent-foreground: 40 20% 97%;
+    --sidebar-border: 24 10% 16%;
+    --sidebar-ring: 18 75% 55%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground font-sans;
+  }
+}

--- a/apps/web/design-sync-styles/tailwind.config.cjs
+++ b/apps/web/design-sync-styles/tailwind.config.cjs
@@ -1,0 +1,74 @@
+/** Tailwind build used only by design-sync to compile a static stylesheet for
+ *  the uploaded design system. Theme mirrors apps/web/tailwind.config.ts. */
+const path = require("path");
+const repo = path.resolve(__dirname, "../../..");
+
+module.exports = {
+  darkMode: ["class"],
+  content: [
+    path.join(repo, "apps/web/src/**/*.{ts,tsx}"),
+    // Authored preview cards, so anything they style also compiles in.
+    path.join(repo, ".design-sync/previews/**/*.tsx"),
+    path.join(__dirname, "candidates.txt"),
+  ],
+  theme: {
+    container: { center: true, padding: "2rem", screens: { "2xl": "1400px" } },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        sidebar: {
+          DEFAULT: "hsl(var(--sidebar-background))",
+          foreground: "hsl(var(--sidebar-foreground))",
+          primary: "hsl(var(--sidebar-primary))",
+          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          ring: "hsl(var(--sidebar-ring))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      fontFamily: {
+        sans: ["var(--font-quicksand)", "sans-serif"],
+        serif: ["var(--font-young-serif)", "serif"],
+      },
+    },
+  },
+  plugins: [require("tailwindcss-animate")],
+};


### PR DESCRIPTION
Imports the web app's shadcn/ui component set into a Claude Design project, so the design agent builds screens with our real components instead of generic ones.

**Project:** https://claude.ai/design/p/d901d8ce-3c98-4c10-a14d-11f441b80480

## What landed there

108 components from `apps/web/src/components/ui/`, grouped into actions / data-display / feedback / forms / layout / navigation / overlays / surfaces. Each ships a typed `.d.ts` contract and a usage doc. 34 of them have hand-authored preview cards — every primary component plus the Card and Sidebar sub-parts — rendered in headless Chromium and checked against the real Warm Stone theme. The other 74 are structural sub-parts (portals, overlays, scroll buttons) that render nothing standalone and show the deliberate floor card.

Final validate: 108/108 previews render cleanly, zero flagged.

## What's in this PR

Only the sync *inputs*. Everything generated (`ds.css`, `candidates.txt`, `ds-bundle/`, `.ds-sync/`) is gitignored.

| Path | What |
|---|---|
| `.design-sync/config.json` | converter config — package, groups, card modes |
| `.design-sync/conventions.md` | prepended to the generated README and inlined into the design agent's prompt |
| `.design-sync/previews/*.tsx` | 34 authored preview cards |
| `.design-sync/NOTES.md` | per-clone setup + the gotchas that cost a debugging cycle |
| `apps/web/design-sync-styles/` | Tailwind build for the shipped stylesheet |
| `apps/web/design-sync-docs/` | 108 per-component docs (set grouping, become `.prompt.md`) |

Two of these live under `apps/web/` rather than `.design-sync/` because the converter bounds `cssEntry` and `docsDir` to the package directory.

## Why the stylesheet is synthesised

This is the least obvious part. A Next.js app has no compiled CSS on disk, and Tailwind only emits utilities it can actually see in `content`. Designs the agent writes later don't exist at build time, so without help they'd reference classes that were never generated and render unstyled.

`gen-candidates.mjs` therefore emits ~18k plausible utility class names (layout, spacing, sizing, type scale, the semantic colour palette, states, breakpoints) purely so those rules exist in the shipped sheet. If a future design comes out partly unstyled, widen that generator — don't hand-edit `ds.css`.

A consequence worth knowing: **arbitrary values in square brackets (`w-[380px]`) produce no CSS and fail silently.** That's documented for the design agent in `conventions.md`, with inline `style` as the escape hatch.

## Notes

- Fonts load from Google Fonts via a stylesheet import, since `next/font` isn't available outside the app. Both families render correctly in the verified cards.
- `toast`/`useToast` live in a `.ts` file the synth entry skipped, so they're pulled in explicitly via `extraEntries`.
- Re-syncs need a `node_modules/@planeatrepeat/web` symlink that pnpm doesn't create, and the stylesheet rebuilt before the converter. Both are the first section of `NOTES.md`.
- Separately noted, not fixed here: `CommandEmpty` in `command.tsx` sets `className` before spreading `{...props}`, so a caller's className replaces its base styles instead of merging through `cn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)